### PR TITLE
Fix Travis CI Build Failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: xenial
+dist: trusty
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: xenial
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_TRAVISCI=phpcs
+      dist: precise
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
     - php: 5.6
       env: WP_TRAVISCI=phpcs
       dist: precise
+      fast_finish: true
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ notifications:
 branches:
   only:
     - master
-    - feature/7-coding-standards
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ matrix:
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_TRAVISCI=phpcs
-      dist: precise
-      fast_finish: true
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
 branches:
   only:
     - master
-    - 7-coding-standards
+    - feature/7-coding-standards
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ notifications:
 branches:
   only:
     - master
+    - 7-coding-standards
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ matrix:
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_TRAVISCI=phpcs
-    - php: 5.3
-      env: WP_VERSION=latest
       dist: precise
 
 before_script:


### PR DESCRIPTION
## Description

Issue: #7 

This removes support for PHP 5.3 which appears to be causing the Travis CI build to fail.

This was tested by adding `feature/7-coding-standards` to the list of branches to build in `.travis.yml`, when viewing the branch in github the build passed while still failing on `master`