### PR TITLE
24: Add Sitemaps Index to robots.txt

### DIFF
--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -15,6 +15,7 @@ class Core_Sitemaps_Index {
 	 */
 	public function bootstrap() {
 		add_action( 'init', array( $this, 'url_rewrites' ), 99 );
+		add_filter( 'robots_txt', array( $this, 'add_robots' ), 0, 2 );
 		add_filter( 'redirect_canonical', array( $this, 'redirect_canonical' ) );
 		add_action( 'template_redirect', array( $this, 'output_sitemap' ) );
 	}
@@ -59,5 +60,21 @@ class Core_Sitemaps_Index {
 			echo '</sitemapindex>';
 			exit;
 		}
+	}
+
+	/**
+	 * Adds the sitemap index to robots.txt.
+	 *
+	 * @param string $output robots.txt output.
+	 * @param bool   $public Whether the site is public or not.
+	 * @return string robots.txt output.
+	 */
+	public function add_robots( $output, $public ) {
+		if ( $public ) {
+			$output .= 'Sitemap: ' . home_url( '/sitemap.xml' ) . "\n";
+
+		}
+
+		return $output;
 	}
 }

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -72,9 +72,7 @@ class Core_Sitemaps_Index {
 	public function add_robots( $output, $public ) {
 		if ( $public ) {
 			$output .= 'Sitemap: ' . home_url( '/sitemap.xml' ) . "\n";
-
 		}
-
 		return $output;
 	}
 }

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -63,6 +63,23 @@ class Core_Sitemaps_Index {
 	}
 
 	/**
+	 * Builds the URL for the sitemap index.
+	 *
+	 * @return string the sitemap index url.
+	 */
+	public function sitemap_index_url() {
+		global $wp_rewrite;
+
+		$url = home_url( '/sitemap.xml');
+
+		if ( ! $wp_rewrite->using_permalinks() ) {
+			$url = add_query_arg( 'sitemap', 'sitemap_index', home_url( '/' ) );
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Adds the sitemap index to robots.txt.
 	 *
 	 * @param string $output robots.txt output.
@@ -71,7 +88,7 @@ class Core_Sitemaps_Index {
 	 */
 	public function add_robots( $output, $public ) {
 		if ( $public ) {
-			$output .= 'Sitemap: ' . home_url( '/sitemap.xml' ) . "\n";
+			$output .= 'Sitemap: ' . esc_url( $this->sitemap_index_url() ) . "\n";
 		}
 		return $output;
 	}


### PR DESCRIPTION
### Issue Number
https://github.com/GoogleChromeLabs/wp-sitemaps/issues/24

### Description
Adds the sitemap index to robots.txt if the site is set to be visible to search engines

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
- Check out branch `feature/24-robots-txt`.
- View `your-local/robots.txt` to see the sitemap index included.
- In the admin, go to `Settings > Reading` and check the Search engine.Visibility check box to discourage visibility.
- View `your-local/robots.txt` again to see the sitemap index is no longer there.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
