### PR TITLE
Basic Sitemaps Provider

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -19,6 +19,7 @@
 
 const CORE_SITEMAPS_POSTS_PER_PAGE = 2000;
 
+require_once __DIR__ . '/inc/class-sitemaps-provider.php';
 require_once __DIR__ . '/inc/class-sitemaps-index.php';
 require_once __DIR__ . '/inc/class-sitemaps-posts.php';
 require_once __DIR__ . '/inc/class-sitemaps-registry.php';

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -4,19 +4,7 @@
  * Builds the sitemap index page that lists the links to all of the sitemaps.
  *
  */
-class Core_Sitemaps_Index {
-	/**
-	 * @var Core_Sitemaps_Registry object
-	 */
-	public $registry;
-
-	/**
-	 * Core_Sitemaps_Index constructor.
-	 */
-	public function __construct() {
-		$this->registry = Core_Sitemaps_Registry::instance();
-	}
-
+class Core_Sitemaps_Index extends Core_Sitemaps_Provider {
 	/**
 	 *
 	 * A helper function to initiate actions, hooks and other features needed.

--- a/inc/class-sitemaps-posts.php
+++ b/inc/class-sitemaps-posts.php
@@ -4,18 +4,13 @@
  * Class Core_Sitemaps_Posts.
  * Builds the sitemap pages for Posts.
  */
-class Core_Sitemaps_Posts {
+class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	/**
-	 * @var Core_Sitemaps_Registry object
+	 * Post type name.
+	 *
+	 * @var string
 	 */
-	public $registry;
-
-	/**
-	 * Core_Sitemaps_Index constructor.
-	 */
-	public function __construct() {
-		$this->registry = Core_Sitemaps_Registry::instance();
-	}
+	protected $post_type = 'post';
 
 	/**
 	 * Bootstrapping the filters.
@@ -40,7 +35,7 @@ class Core_Sitemaps_Posts {
 		$paged   = get_query_var( 'paged' );
 
 		if ( 'posts' === $sitemap ) {
-			$content = $this->get_content_per_page( 'post', $paged );
+			$content = $this->get_content_per_page( $this->post_type, $paged );
 
 			header( 'Content-type: application/xml; charset=UTF-8' );
 			echo '<?xml version="1.0" encoding="UTF-8" ?>';

--- a/inc/class-sitemaps-posts.php
+++ b/inc/class-sitemaps-posts.php
@@ -36,55 +36,8 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 
 		if ( 'posts' === $sitemap ) {
 			$content = $this->get_content_per_page( $this->post_type, $paged );
-
-			header( 'Content-type: application/xml; charset=UTF-8' );
-			echo '<?xml version="1.0" encoding="UTF-8" ?>';
-			echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
-			foreach ( $content as $post ) {
-				$url_data = array(
-					'loc'        => get_permalink( $post ),
-					// DATE_W3C does not contain a timezone offset, so UTC date must be used.
-					'lastmod'    => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
-					'priority'   => '0.5',
-					'changefreq' => 'monthly',
-				);
-				printf(
-					'<url>
-<loc>%1$s</loc>
-<lastmod>%2$s</lastmod>
-<changefreq>%3$s</changefreq>
-<priority>%4$s</priority>
-</url>',
-					esc_html( $url_data['loc'] ),
-					esc_html( $url_data['lastmod'] ),
-					esc_html( $url_data['changefreq'] ),
-					esc_html( $url_data['priority'] )
-				);
-			}
-			echo '</urlset>';
+			$this->render( $content );
 			exit;
 		}
-	}
-
-	/**
-	 * Get content for a page.
-	 *
-	 * @param string $post_type Name of the post_type.
-	 * @param int    $page_num Page of results.
-	 *
-	 * @return int[]|WP_Post[] Query result.
-	 */
-	public function get_content_per_page( $post_type, $page_num = 1 ) {
-		$query = new WP_Query();
-
-		return $query->query(
-			array(
-				'orderby'        => 'ID',
-				'order'          => 'ASC',
-				'post_type'      => $post_type,
-				'posts_per_page' => CORE_SITEMAPS_POSTS_PER_PAGE,
-				'paged'          => $page_num,
-			)
-		);
 	}
 }

--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -23,4 +23,59 @@ class Core_Sitemaps_Provider {
 	public function __construct() {
 		$this->registry = Core_Sitemaps_Registry::instance();
 	}
+
+	/**
+	 * General renderer for Sitemap Provider instances.
+	 *
+	 * @param WP_Post[] $content List of WP_Post objects.
+	 */
+	public function render( $content ) {
+		header( 'Content-type: application/xml; charset=UTF-8' );
+		echo '<?xml version="1.0" encoding="UTF-8" ?>';
+		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+		foreach ( $content as $post ) {
+			$url_data = array(
+				'loc'        => get_permalink( $post ),
+				// DATE_W3C does not contain a timezone offset, so UTC date must be used.
+				'lastmod'    => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
+				'priority'   => '0.5',
+				'changefreq' => 'monthly',
+			);
+			printf(
+				'<url>
+<loc>%1$s</loc>
+<lastmod>%2$s</lastmod>
+<changefreq>%3$s</changefreq>
+<priority>%4$s</priority>
+</url>',
+				esc_html( $url_data['loc'] ),
+				esc_html( $url_data['lastmod'] ),
+				esc_html( $url_data['changefreq'] ),
+				esc_html( $url_data['priority'] )
+			);
+		}
+		echo '</urlset>';
+	}
+
+	/**
+	 * Get content for a page.
+	 *
+	 * @param string $post_type Name of the post_type.
+	 * @param int    $page_num Page of results.
+	 *
+	 * @return int[]|WP_Post[] Query result.
+	 */
+	public function get_content_per_page( $post_type, $page_num = 1 ) {
+		$query = new WP_Query();
+
+		return $query->query(
+			array(
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+				'post_type'      => $post_type,
+				'posts_per_page' => CORE_SITEMAPS_POSTS_PER_PAGE,
+				'paged'          => $page_num,
+			)
+		);
+	}
 }

--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Class Core_Sitemaps_Provider
+ */
+class Core_Sitemaps_Provider {
+	/**
+	 * Registry instance
+	 *
+	 * @var Core_Sitemaps_Registry
+	 */
+	public $registry;
+	/**
+	 * Post Type name
+	 *
+	 * @var string
+	 */
+	protected $post_type = '';
+
+	/**
+	 * Core_Sitemaps_Provider constructor.
+	 */
+	public function __construct() {
+		$this->registry = Core_Sitemaps_Registry::instance();
+	}
+}


### PR DESCRIPTION
### Description
Basic Sitemaps Provider class. This allows us to share code used by all sitemaps providers.

This exposes the registry in all classes that extend from this class. In addition the post_type property can be set on post type providers which can simplify the code base further.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
existing sitemaps continue to load.

### Acceptance criteris
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [x] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
