### PR TITLE
#37 Core Sitemap Renderer

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -28,5 +28,6 @@ require_once __DIR__ . '/inc/class-sitemaps-index.php';
 require_once __DIR__ . '/inc/class-sitemaps-pages.php';
 require_once __DIR__ . '/inc/class-sitemaps-posts.php';
 require_once __DIR__ . '/inc/class-sitemaps-registry.php';
+require_once __DIR__ . '/inc/class-sitemaps-renderer.php';
 
 $core_sitemaps = new Core_Sitemaps();

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -67,7 +67,7 @@ class Core_Sitemaps_Index extends Core_Sitemaps_Provider {
 		if ( 'index' === $sitemap_index ) {
 			$sitemaps_urls = $this->registry->get_sitemaps();
 			$renderer      = new Core_Sitemaps_Renderer();
-			$renderer->render_index( $sitemaps_urls );
+			$renderer->render_sitemapindex( $sitemaps_urls );
 			exit;
 		}
 	}

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -55,22 +55,6 @@ class Core_Sitemaps_Index extends Core_Sitemaps_Provider {
 	}
 
 	/**
-	 * Add the correct xml to any given url.
-	 *
-	 * @todo This will also need to be updated with the last modified information as well.
-	 *
-	 * @return string $markup
-	 */
-	public function get_index_url_markup( $url ) {
-		$markup = '<sitemap>' . "\n";
-		$markup .= '<loc>' . esc_url( $url ) . '</loc>' . "\n";
-		$markup .= '<lastmod>2004-10-01T18:23:17+00:00</lastmod>' . "\n";
-		$markup .= '</sitemap>' . "\n";
-
-		return $markup;
-	}
-
-	/**
 	 * Produce XML to output.
 	 *
 	 * @todo At the moment this outputs the rewrite rule for each sitemap rather than the URL.
@@ -79,19 +63,11 @@ class Core_Sitemaps_Index extends Core_Sitemaps_Provider {
 	 */
 	public function render_sitemap() {
 		$sitemap_index = get_query_var( 'sitemap' );
-		$sitemaps_urls = $this->registry->get_sitemaps();
 
 		if ( 'index' === $sitemap_index ) {
-			header( 'Content-type: application/xml; charset=UTF-8' );
-
-			echo '<?xml version="1.0" encoding="UTF-8" ?>';
-			echo '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
-
-			foreach ( $sitemaps_urls as $link ) {
-				echo $this->get_index_url_markup( $link['slug'] );
-			}
-
-			echo '</sitemapindex>';
+			$sitemaps_urls = $this->registry->get_sitemaps();
+			$renderer      = new Core_Sitemaps_Renderer();
+			$renderer->render_index( $sitemaps_urls );
 			exit;
 		}
 	}

--- a/inc/class-sitemaps-pages.php
+++ b/inc/class-sitemaps-pages.php
@@ -42,8 +42,9 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 		$paged   = get_query_var( 'paged' );
 
 		if ( 'pages' === $sitemap ) {
-			$content = $this->get_content_per_page( $this->post_type, $paged );
-			$this->render( $content );
+			$content  = $this->get_content_per_page( $this->post_type, $paged );
+			$renderer = new Core_Sitemaps_Renderer();
+			$renderer->render_sitemap( $content );
 			exit;
 		}
 	}

--- a/inc/class-sitemaps-pages.php
+++ b/inc/class-sitemaps-pages.php
@@ -44,7 +44,7 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 		if ( 'pages' === $sitemap ) {
 			$content  = $this->get_content_per_page( $this->post_type, $paged );
 			$renderer = new Core_Sitemaps_Renderer();
-			$renderer->render_sitemap( $content );
+			$renderer->render_urlset( $content );
 			exit;
 		}
 	}

--- a/inc/class-sitemaps-posts.php
+++ b/inc/class-sitemaps-posts.php
@@ -45,7 +45,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 		if ( 'posts' === $sitemap ) {
 			$content  = $this->get_content_per_page( $this->post_type, $paged );
 			$renderer = new Core_Sitemaps_Renderer();
-			$renderer->render_sitemap( $content );
+			$renderer->render_urlset( $content );
 			exit;
 		}
 	}

--- a/inc/class-sitemaps-posts.php
+++ b/inc/class-sitemaps-posts.php
@@ -43,8 +43,9 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 		$paged   = get_query_var( 'paged' );
 
 		if ( 'posts' === $sitemap ) {
-			$content = $this->get_content_per_page( $this->post_type, $paged );
-			$this->render( $content );
+			$content  = $this->get_content_per_page( $this->post_type, $paged );
+			$renderer = new Core_Sitemaps_Renderer();
+			$renderer->render_sitemap( $content );
 			exit;
 		}
 	}

--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -41,39 +41,6 @@ class Core_Sitemaps_Provider {
 	}
 
 	/**
-	 * General renderer for Sitemap Provider instances.
-	 *
-	 * @param WP_Post[] $content List of WP_Post objects.
-	 */
-	public function render( $content ) {
-		header( 'Content-type: application/xml; charset=UTF-8' );
-		echo '<?xml version="1.0" encoding="UTF-8" ?>';
-		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
-		foreach ( $content as $post ) {
-			$url_data = array(
-				'loc'        => get_permalink( $post ),
-				// DATE_W3C does not contain a timezone offset, so UTC date must be used.
-				'lastmod'    => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
-				'priority'   => '0.5',
-				'changefreq' => 'monthly',
-			);
-			printf(
-				'<url>
-<loc>%1$s</loc>
-<lastmod>%2$s</lastmod>
-<changefreq>%3$s</changefreq>
-<priority>%4$s</priority>
-</url>',
-				esc_html( $url_data['loc'] ),
-				esc_html( $url_data['lastmod'] ),
-				esc_html( $url_data['changefreq'] ),
-				esc_html( $url_data['priority'] )
-			);
-		}
-		echo '</urlset>';
-	}
-
-	/**
 	 * Get content for a page.
 	 *
 	 * @param string $post_type Name of the post_type.

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Rendering Sitemaps Data to XML.
+ * Rendering Sitemaps Data to XML in accorance with sitemap protocol.
  *
  * @package Core_Sitemap
  */
@@ -10,7 +10,7 @@
  */
 class Core_Sitemaps_Renderer {
 	/**
-	 * Render a sitemapindex.
+	 * Render a sitemap index.
 	 *
 	 * @param array $sitemaps List of sitemaps, see \Core_Sitemaps_Registry::$sitemaps.
 	 */

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -9,66 +9,40 @@
  * Class Core_Sitemaps_Renderer
  */
 class Core_Sitemaps_Renderer {
-	public function render_index( $sitemaps_urls ) {
-
-		header( 'Content-type: application/xml; charset=UTF-8' );
-
-		echo '<?xml version="1.0" encoding="UTF-8" ?>';
-		echo '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
-
-		foreach ( $sitemaps_urls as $link ) {
-			echo $this->get_index_url_markup( $link['slug'] );
-		}
-
-		echo '</sitemapindex>';
-	}
-
 	/**
-	 * Add the correct xml to any given url.
+	 * Render a sitemapindex.
 	 *
-	 * @return string $markup
-	 * @todo This will also need to be updated with the last modified information as well.
-	 *
+	 * @param array $sitemaps List of sitemaps, see \Core_Sitemaps_Registry::$sitemaps.
 	 */
-	public function get_index_url_markup( $url ) {
-		$markup = '<sitemap>' . "\n";
-		$markup .= '<loc>' . esc_url( $url ) . '</loc>' . "\n";
-		$markup .= '<lastmod>2004-10-01T18:23:17+00:00</lastmod>' . "\n";
-		$markup .= '</sitemap>' . "\n";
+	public function render_sitemapindex( $sitemaps ) {
+		header( 'Content-type: application/xml; charset=UTF-8' );
+		$sitemap_index = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8" ?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>' );
 
-		return $markup;
+		foreach ( $sitemaps as $link ) {
+			$sitemap = $sitemap_index->addChild( 'sitemap' );
+			$sitemap->addChild( 'loc', esc_url( $link['slug'] ) );
+			$sitemap->addChild( 'lastmod', '2004-10-01T18:23:17+00:00' );
+		}
+		echo $sitemap_index->asXML();
+
 	}
 
 	/**
-	 * Render a sitemap.
+	 * Render a sitemap urlset.
 	 *
 	 * @param WP_Post[] $content List of WP_Post objects.
 	 */
-	public function render_sitemap( $content ) {
+	public function render_urlset( $content ) {
 		header( 'Content-type: application/xml; charset=UTF-8' );
-		echo '<?xml version="1.0" encoding="UTF-8" ?>';
-		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+		$urlset = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8" ?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>' );
+
 		foreach ( $content as $post ) {
-			$url_data = array(
-				'loc'        => get_permalink( $post ),
-				// DATE_W3C does not contain a timezone offset, so UTC date must be used.
-				'lastmod'    => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
-				'priority'   => '0.5',
-				'changefreq' => 'monthly',
-			);
-			printf(
-				'<url>
-<loc>%1$s</loc>
-<lastmod>%2$s</lastmod>
-<changefreq>%3$s</changefreq>
-<priority>%4$s</priority>
-</url>',
-				esc_html( $url_data['loc'] ),
-				esc_html( $url_data['lastmod'] ),
-				esc_html( $url_data['changefreq'] ),
-				esc_html( $url_data['priority'] )
-			);
+			$url = $urlset->addChild( 'url' );
+			$url->addChild( 'loc', esc_url( get_permalink( $post ) ) );
+			$url->addChild( 'lastmod', mysql2date( DATE_W3C, $post->post_modified_gmt, false ) );
+			$url->addChild( 'priority', '0.5' );
+			$url->addChild( 'changefreq', 'monthly' );
 		}
-		echo '</urlset>';
+		echo $urlset->asXML();
 	}
 }

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Rendering Sitemaps Data to XML.
+ *
+ * @package Core_Sitemap
+ */
+
+/**
+ * Class Core_Sitemaps_Renderer
+ */
+class Core_Sitemaps_Renderer {
+}

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -9,4 +9,33 @@
  * Class Core_Sitemaps_Renderer
  */
 class Core_Sitemaps_Renderer {
+	public function render_index( $sitemaps_urls ) {
+
+		header( 'Content-type: application/xml; charset=UTF-8' );
+
+		echo '<?xml version="1.0" encoding="UTF-8" ?>';
+		echo '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+
+		foreach ( $sitemaps_urls as $link ) {
+			echo $this->get_index_url_markup( $link['slug'] );
+		}
+
+		echo '</sitemapindex>';
+	}
+
+	/**
+	 * Add the correct xml to any given url.
+	 *
+	 * @return string $markup
+	 * @todo This will also need to be updated with the last modified information as well.
+	 *
+	 */
+	public function get_index_url_markup( $url ) {
+		$markup = '<sitemap>' . "\n";
+		$markup .= '<loc>' . esc_url( $url ) . '</loc>' . "\n";
+		$markup .= '<lastmod>2004-10-01T18:23:17+00:00</lastmod>' . "\n";
+		$markup .= '</sitemap>' . "\n";
+
+		return $markup;
+	}
 }

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -38,4 +38,37 @@ class Core_Sitemaps_Renderer {
 
 		return $markup;
 	}
+
+	/**
+	 * Render a sitemap.
+	 *
+	 * @param WP_Post[] $content List of WP_Post objects.
+	 */
+	public function render_sitemap( $content ) {
+		header( 'Content-type: application/xml; charset=UTF-8' );
+		echo '<?xml version="1.0" encoding="UTF-8" ?>';
+		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+		foreach ( $content as $post ) {
+			$url_data = array(
+				'loc'        => get_permalink( $post ),
+				// DATE_W3C does not contain a timezone offset, so UTC date must be used.
+				'lastmod'    => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
+				'priority'   => '0.5',
+				'changefreq' => 'monthly',
+			);
+			printf(
+				'<url>
+<loc>%1$s</loc>
+<lastmod>%2$s</lastmod>
+<changefreq>%3$s</changefreq>
+<priority>%4$s</priority>
+</url>',
+				esc_html( $url_data['loc'] ),
+				esc_html( $url_data['lastmod'] ),
+				esc_html( $url_data['changefreq'] ),
+				esc_html( $url_data['priority'] )
+			);
+		}
+		echo '</urlset>';
+	}
 }

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -24,7 +24,6 @@ class Core_Sitemaps_Renderer {
 			$sitemap->addChild( 'lastmod', '2004-10-01T18:23:17+00:00' );
 		}
 		echo $sitemap_index->asXML();
-
 	}
 
 	/**


### PR DESCRIPTION
### Issue Number
Fixes #37 

### Description
Instead of rendering the data with a class method within the sitemap provider (SP),  we would like to have a sitemap renderer class which would take uniform sitemap data and render out the xml (applying XSL styling is out of scope of this ticket).

Memory is not a problem currently, runtime is a potential concern but outside scope on this PR on 2000 posts. The profiler shows this is due to sanitising terms when processing the permalink, so this can be addressed at a later date.
![image](https://user-images.githubusercontent.com/594871/68290776-70698980-0080-11ea-8c83-8da2fc6c690c.png)

A typical post provider would render as follows:
```php
	public function render_sitemap() {
		$sitemap = get_query_var( 'sitemap' );
		$paged   = get_query_var( 'paged' );

		if ( 'posts' === $sitemap ) {
			$content  = $this->get_content_per_page( $this->post_type, $paged );
			$renderer = new Core_Sitemaps_Renderer();
			$renderer->render_urlset( $content );
			exit;
		}
	}
```

Data  is passed to a renderer class which sanitizes and renders the xml sitemap and xml index. 

- [x] Unified renderer implementation.
- [x] Allows both Index and regular sitemaps to render.
- [ ] Can be extended and replaced by developers.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Breaking change as the render method was moved and renamed.

### Steps to test
Reapply the permalinks if required, then visit the links in the screenshot.

### Acceptance criteris
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [x] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
