### PR TITLE
FIX: Rename $post_type to $object_type

### DIFF
--- a/inc/class-sitemaps-pages.php
+++ b/inc/class-sitemaps-pages.php
@@ -10,7 +10,7 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 	 *
 	 * @var string
 	 */
-	protected $post_type = 'page';
+	protected $object_type = 'page';
 	/**
 	 * Sitemap name
 	 * Used for building sitemap URLs.
@@ -42,7 +42,7 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 		$paged   = get_query_var( 'paged' );
 
 		if ( 'pages' === $sitemap ) {
-			$content  = $this->get_content_per_page( $this->post_type, $paged );
+			$content  = $this->get_content_per_page( $this->object_type, $paged );
 			$renderer = new Core_Sitemaps_Renderer();
 			$renderer->render_urlset( $content );
 			exit;

--- a/inc/class-sitemaps-posts.php
+++ b/inc/class-sitemaps-posts.php
@@ -10,7 +10,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	 *
 	 * @var string
 	 */
-	protected $post_type = 'post';
+	protected $object_type = 'post';
 
 	/**
 	 * Sitemap name
@@ -31,7 +31,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	/**
 	 * Sets up rewrite rule for sitemap_index.
 	 */
-	public function register_sitemap( $post_type ) {
+	public function register_sitemap() {
 		$this->registry->add_sitemap( $this->name, '^sitemap-posts\.xml$', esc_url( $this->get_sitemap_url( $this->name ) ) );
 	}
 
@@ -43,7 +43,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 		$paged   = get_query_var( 'paged' );
 
 		if ( 'posts' === $sitemap ) {
-			$content  = $this->get_content_per_page( $this->post_type, $paged );
+			$content  = $this->get_content_per_page( $this->object_type, $paged );
 			$renderer = new Core_Sitemaps_Renderer();
 			$renderer->render_urlset( $content );
 			exit;

--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -17,11 +17,12 @@ class Core_Sitemaps_Provider {
 	 */
 	public $registry;
 	/**
-	 * Post Type name
+	 * Object Type name
+	 * This can be a post type or term.
 	 *
 	 * @var string
 	 */
-	protected $post_type = '';
+	protected $object_type = '';
 
 	/**
 	 * Sitemap name
@@ -43,19 +44,19 @@ class Core_Sitemaps_Provider {
 	/**
 	 * Get content for a page.
 	 *
-	 * @param string $post_type Name of the post_type.
+	 * @param string $object_type Name of the object_type.
 	 * @param int    $page_num Page of results.
 	 *
 	 * @return int[]|WP_Post[] Query result.
 	 */
-	public function get_content_per_page( $post_type, $page_num = 1 ) {
+	public function get_content_per_page( $object_type, $page_num = 1 ) {
 		$query = new WP_Query();
 
 		return $query->query(
 			array(
 				'orderby'        => 'ID',
 				'order'          => 'ASC',
-				'post_type'      => $post_type,
+				'post_type'      => $object_type,
 				'posts_per_page' => CORE_SITEMAPS_POSTS_PER_PAGE,
 				'paged'          => $page_num,
 			)


### PR DESCRIPTION
### Description
This change is so that we can use the same variable to pass both post types and taxonomies to the `get_content_per_page()` method instead of having to add another argument. 

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This needs to be updated everywhere `$post_type` is used otherwise it will break all the things.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross-browser / device tested.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
