### PR TITLE
#44 Refactor sitemap registration pattern.

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -29,5 +29,7 @@ require_once __DIR__ . '/inc/class-sitemaps-pages.php';
 require_once __DIR__ . '/inc/class-sitemaps-posts.php';
 require_once __DIR__ . '/inc/class-sitemaps-registry.php';
 require_once __DIR__ . '/inc/class-sitemaps-renderer.php';
+require_once __DIR__ . '/inc/functions.php';
 
 $core_sitemaps = new Core_Sitemaps();
+$core_sitemaps->bootstrap();

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -10,7 +10,7 @@
  * Class Core_Sitemaps_Index.
  * Builds the sitemap index page that lists the links to all of the sitemaps.
  */
-class Core_Sitemaps_Index extends Core_Sitemaps_Provider {
+class Core_Sitemaps_Index {
 	/**
 	 * Sitemap name
 	 * Used for building sitemap URLs.
@@ -22,22 +22,18 @@ class Core_Sitemaps_Index extends Core_Sitemaps_Provider {
 	/**
 	 *
 	 * A helper function to initiate actions, hooks and other features needed.
-	 *
-	 * @uses add_action()
-	 * @uses add_filter()
 	 */
 	public function bootstrap() {
-		add_action( 'core_sitemaps_setup_sitemaps', array( $this, 'register_sitemap' ), 99 );
+		// Set up rewrites.
+		add_rewrite_tag( '%sitemap%', '([^?]+)' );
+		add_rewrite_rule( '^sitemap\.xml$', 'index.php?sitemap=index', 'top' );
+
+		// Add filters.
 		add_filter( 'robots_txt', array( $this, 'add_robots' ), 0, 2 );
 		add_filter( 'redirect_canonical', array( $this, 'redirect_canonical' ) );
-		add_action( 'template_redirect', array( $this, 'render_sitemap' ) );
-	}
 
-	/**
-	 * Sets up rewrite rule for sitemap_index.
-	 */
-	public function register_sitemap() {
-		$this->registry->add_sitemap( $this->name, 'sitemap\.xml$', esc_url( $this->get_sitemap_url( $this->name ) ) );
+		// Add actions.
+		add_action( 'template_redirect', array( $this, 'render_sitemap' ) );
 	}
 
 	/**
@@ -65,9 +61,9 @@ class Core_Sitemaps_Index extends Core_Sitemaps_Provider {
 		$sitemap_index = get_query_var( 'sitemap' );
 
 		if ( 'index' === $sitemap_index ) {
-			$sitemaps_urls = $this->registry->get_sitemaps();
+			$sitemaps = core_sitemaps_get_sitemaps();
 			$renderer      = new Core_Sitemaps_Renderer();
-			$renderer->render_sitemapindex( $sitemaps_urls );
+			$renderer->render_index( $sitemaps );
 			exit;
 		}
 	}

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -24,7 +24,7 @@ class Core_Sitemaps_Index {
 	 *
 	 * A helper function to initiate actions, hooks and other features needed.
 	 */
-	public function bootstrap() {
+	public function setup_sitemap() {
 		// Set up rewrites.
 		add_rewrite_tag( '%sitemap%', '([^?]+)' );
 		add_rewrite_rule( '^sitemap\.xml$', 'index.php?sitemap=index', 'top' );

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -19,7 +19,12 @@ class Core_Sitemaps_Index {
 	 * @var string
 	 */
 	protected $name = 'index';
-
+	/**
+	 * Core_Sitemaps_Index constructor.
+	 */
+	public function __construct() {
+		$this->renderer = new Core_Sitemaps_Renderer();
+	}
 	/**
 	 *
 	 * A helper function to initiate actions, hooks and other features needed.
@@ -63,8 +68,7 @@ class Core_Sitemaps_Index {
 
 		if ( 'index' === $sitemap_index ) {
 			$sitemaps = core_sitemaps_get_sitemaps();
-			$renderer = new Core_Sitemaps_Renderer();
-			$renderer->render_index( $sitemaps );
+			$this->renderer->render_index( $sitemaps );
 			exit;
 		}
 	}
@@ -78,8 +82,7 @@ class Core_Sitemaps_Index {
 	 */
 	public function add_robots( $output, $public ) {
 		if ( $public ) {
-			$renderer = new Core_Sitemaps_Renderer();
-			$output .= 'Sitemap: ' . esc_url( $renderer->get_sitemap_url( $this->name ) ) . "\n";
+			$output .= 'Sitemap: ' . esc_url( $this->renderer->get_sitemap_url( $this->name ) ) . "\n";
 		}
 		return $output;
 	}

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -12,7 +12,8 @@
  */
 class Core_Sitemaps_Index {
 	/**
-	 * Sitemap name
+	 * Sitemap name.
+	 *
 	 * Used for building sitemap URLs.
 	 *
 	 * @var string

--- a/inc/class-sitemaps-index.php
+++ b/inc/class-sitemaps-index.php
@@ -63,7 +63,7 @@ class Core_Sitemaps_Index {
 
 		if ( 'index' === $sitemap_index ) {
 			$sitemaps = core_sitemaps_get_sitemaps();
-			$renderer      = new Core_Sitemaps_Renderer();
+			$renderer = new Core_Sitemaps_Renderer();
 			$renderer->render_index( $sitemaps );
 			exit;
 		}
@@ -78,7 +78,8 @@ class Core_Sitemaps_Index {
 	 */
 	public function add_robots( $output, $public ) {
 		if ( $public ) {
-			$output .= 'Sitemap: ' . esc_url( $this->get_sitemap_url( $this->name ) ) . "\n";
+			$renderer = new Core_Sitemaps_Renderer();
+			$output .= 'Sitemap: ' . esc_url( $renderer->get_sitemap_url( $this->name ) ) . "\n";
 		}
 		return $output;
 	}

--- a/inc/class-sitemaps-pages.php
+++ b/inc/class-sitemaps-pages.php
@@ -37,7 +37,7 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 	 *
 	 * @var string
 	 */
-	public $slug = 'page';
+	public $slug = 'pages';
 
 	/**
 	 * Produce XML to output.

--- a/inc/class-sitemaps-pages.php
+++ b/inc/class-sitemaps-pages.php
@@ -22,7 +22,7 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 	public $name = 'pages';
 
 	/**
-	 * Sitemap route
+	 * Sitemap route.
 	 *
 	 * Regex pattern used when building the route for a sitemap.
 	 *
@@ -31,7 +31,7 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 	public $route = '^sitemap-pages\.xml$';
 
 	/**
-	 * Sitemap slug
+	 * Sitemap slug.
 	 *
 	 * Used for building sitemap URLs.
 	 *

--- a/inc/class-sitemaps-pages.php
+++ b/inc/class-sitemaps-pages.php
@@ -11,28 +11,33 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 	 * @var string
 	 */
 	protected $object_type = 'page';
+
 	/**
 	 * Sitemap name
+	 *
 	 * Used for building sitemap URLs.
 	 *
 	 * @var string
 	 */
-	protected $name = 'pages';
+	public $name = 'pages';
 
 	/**
-	 * Bootstrapping the filters.
+	 * Sitemap route
+	 *
+	 * Regex pattern used when building the route for a sitemap.
+	 *
+	 * @var string
 	 */
-	public function bootstrap() {
-		add_action( 'core_sitemaps_setup_sitemaps', array( $this, 'register_sitemap' ), 99 );
-		add_action( 'template_redirect', array( $this, 'render_sitemap' ) );
-	}
+	public $route = '^sitemap-pages\.xml$';
 
 	/**
-	 * Sets up rewrite rule for sitemap_index.
+	 * Sitemap slug
+	 *
+	 * Used for building sitemap URLs.
+	 *
+	 * @var string
 	 */
-	public function register_sitemap() {
-		$this->registry->add_sitemap( $this->name, '^sitemap-pages\.xml$', esc_url( $this->get_sitemap_url( $this->name ) ) );
-	}
+	public $slug = 'page';
 
 	/**
 	 * Produce XML to output.

--- a/inc/class-sitemaps-posts.php
+++ b/inc/class-sitemaps-posts.php
@@ -14,26 +14,30 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 
 	/**
 	 * Sitemap name
+	 *
 	 * Used for building sitemap URLs.
 	 *
 	 * @var string
 	 */
-	protected $name = 'posts';
+	public $name = 'posts';
 
 	/**
-	 * Bootstrapping the filters.
+	 * Sitemap route
+	 *
+	 * Regex pattern used when building the route for a sitemap.
+	 *
+	 * @var string
 	 */
-	public function bootstrap() {
-		add_action( 'core_sitemaps_setup_sitemaps', array( $this, 'register_sitemap' ), 99 );
-		add_action( 'template_redirect', array( $this, 'render_sitemap' ) );
-	}
+	public $route = '^sitemap-posts\.xml$';
 
 	/**
-	 * Sets up rewrite rule for sitemap_index.
+	 * Sitemap slug
+	 *
+	 * Used for building sitemap URLs.
+	 *
+	 * @var string
 	 */
-	public function register_sitemap() {
-		$this->registry->add_sitemap( $this->name, '^sitemap-posts\.xml$', esc_url( $this->get_sitemap_url( $this->name ) ) );
-	}
+	public $slug = 'posts';
 
 	/**
 	 * Produce XML to output.

--- a/inc/class-sitemaps-posts.php
+++ b/inc/class-sitemaps-posts.php
@@ -13,7 +13,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	protected $object_type = 'post';
 
 	/**
-	 * Sitemap name
+	 * Sitemap name.
 	 *
 	 * Used for building sitemap URLs.
 	 *
@@ -22,7 +22,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	public $name = 'posts';
 
 	/**
-	 * Sitemap route
+	 * Sitemap route.
 	 *
 	 * Regex pattern used when building the route for a sitemap.
 	 *
@@ -31,7 +31,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	public $route = '^sitemap-posts\.xml$';
 
 	/**
-	 * Sitemap slug
+	 * Sitemap slug.
 	 *
 	 * Used for building sitemap URLs.
 	 *

--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -10,15 +10,9 @@
  * Class Core_Sitemaps_Provider
  */
 class Core_Sitemaps_Provider {
+
 	/**
-	 * Registry instance
-	 *
-	 * @var Core_Sitemaps_Registry
-	 */
-	public $registry;
-	/**
-	 * Object Type name
-	 * This can be a post type or term.
+	 * Post type name.
 	 *
 	 * @var string
 	 */
@@ -26,20 +20,30 @@ class Core_Sitemaps_Provider {
 
 	/**
 	 * Sitemap name
+	 *
 	 * Used for building sitemap URLs.
 	 *
 	 * @var string
 	 */
-	protected $name = '';
+	public $name = '';
 
 	/**
-	 * Setup a link to the registry.
+	 * Sitemap route
 	 *
-	 * @param Core_Sitemaps_Registry $instance Registry instance.
+	 * Regex pattern used when building the route for a sitemap.
+	 *
+	 * @var string
 	 */
-	public function set_registry( $instance ) {
-		$this->registry = $instance;
-	}
+	public $route = '';
+
+	/**
+	 * Sitemap slug
+	 *
+	 * Used for building sitemap URLs.
+	 *
+	 * @var string
+	 */
+	public $slug = '';
 
 	/**
 	 * Get content for a page.
@@ -61,30 +65,5 @@ class Core_Sitemaps_Provider {
 				'paged'          => $page_num,
 			)
 		);
-	}
-
-	/**
-	 * Builds the URL for the sitemaps.
-	 *
-	 * @return string the sitemap index url.
-	 */
-	public function get_sitemap_url( $name ) {
-		global $wp_rewrite;
-
-		if ( $name === 'index' ) {
-			$url = home_url( '/sitemap.xml' );
-
-			if ( ! $wp_rewrite->using_permalinks() ) {
-				$url = add_query_arg( 'sitemap', 'index', home_url( '/' ) );
-			}
-		} else {
-			$url = home_url( sprintf( '/sitemap-%1$s.xml', $name ) );
-
-			if ( ! $wp_rewrite->using_permalinks() ) {
-				$url = add_query_arg( 'sitemap', $name, home_url( '/' ) );
-			}
-		}
-
-		return $url;
 	}
 }

--- a/inc/class-sitemaps-registry.php
+++ b/inc/class-sitemaps-registry.php
@@ -17,8 +17,8 @@ class Core_Sitemaps_Registry {
 	/**
 	 * Add a sitemap with route to the registry.
 	 *
-	 * @param string                $name  Name of the sitemap.
-	 * @param Core_Sitemap_Provider $provider Regex route of the sitemap.
+	 * @param string                $name      Name of the sitemap.
+	 * @param Core_Sitemaps_Provider $provider Instance of a Core_Sitemaps_Provider.
 	 * @return bool True if the sitemap was added, false if it wasn't as it's name was already registered.
 	 */
 	public function add_sitemap( $name, $provider ) {

--- a/inc/class-sitemaps-registry.php
+++ b/inc/class-sitemaps-registry.php
@@ -15,33 +15,22 @@ class Core_Sitemaps_Registry {
 	private $sitemaps = [];
 
 	/**
-	 * Core_Sitemaps_Registry constructor.
-	 *  Setup all registered sitemap data providers, after all are registered at priority 99.
-	 */
-	public function __construct() {
-		add_action( 'init', array( $this, 'setup_sitemaps' ), 100 );
-	}
-
-	/**
 	 * Add a sitemap with route to the registry.
 	 *
-	 * @param string $name Name of the sitemap.
-	 * @param string $route Regex route of the sitemap.
-	 * @param string $slug URL of the sitemap.
-	 * @param array  $args List of other arguments.
-	 *
+	 * @param string                $name  Name of the sitemap.
+	 * @param Core_Sitemap_Provider $provider Regex route of the sitemap.
 	 * @return bool True if the sitemap was added, false if it wasn't as it's name was already registered.
 	 */
-	public function add_sitemap( $name, $route, $slug, $args = [] ) {
+	public function add_sitemap( $name, $provider ) {
 		if ( isset( $this->sitemaps[ $name ] ) ) {
 			return false;
 		}
 
-		$this->sitemaps[ $name ] = [
-			'route' => $route,
-			'slug'  => $slug,
-			'args'  => $args,
-		];
+		if ( ! is_a( $provider, 'Core_Sitemaps_Provider' ) ) {
+			return false;
+		}
+
+		$this->sitemaps[ $name ] = $provider;
 
 		return true;
 	}
@@ -50,7 +39,6 @@ class Core_Sitemaps_Registry {
 	 * Remove sitemap by name.
 	 *
 	 * @param string $name Sitemap name.
-	 *
 	 * @return array Remaining sitemaps.
 	 */
 	public function remove_sitemap( $name ) {
@@ -76,16 +64,28 @@ class Core_Sitemaps_Registry {
 	}
 
 	/**
-	 * Setup rewrite rules for all registered sitemaps.
+	 * Get the URL for a specific sitemap.
 	 *
-	 * @return void
+	 * @param string $name The name of the sitemap to get a URL for.
+	 * @return string the sitemap index url.
 	 */
-	public function setup_sitemaps() {
-		do_action( 'core_sitemaps_setup_sitemaps' );
+	public function get_sitemap_url( $name ) {
+		global $wp_rewrite;
 
-		foreach ( $this->sitemaps as $name => $sitemap ) {
-			add_rewrite_tag( '%sitemap%', $name );
-			add_rewrite_rule( $sitemap['route'], 'index.php?sitemap=' . $name, 'top' );
+		if ( $name === 'index' ) {
+			$url = home_url( '/sitemap.xml' );
+
+			if ( ! $wp_rewrite->using_permalinks() ) {
+				$url = add_query_arg( 'sitemap', 'index', home_url( '/' ) );
+			}
+		} else {
+			$url = home_url( sprintf( '/sitemap-%1$s.xml', $name ) );
+
+			if ( ! $wp_rewrite->using_permalinks() ) {
+				$url = add_query_arg( 'sitemap', $name, home_url( '/' ) );
+			}
 		}
+
+		return $url;
 	}
 }

--- a/inc/class-sitemaps-registry.php
+++ b/inc/class-sitemaps-registry.php
@@ -62,30 +62,4 @@ class Core_Sitemaps_Registry {
 			return $this->sitemaps;
 		}
 	}
-
-	/**
-	 * Get the URL for a specific sitemap.
-	 *
-	 * @param string $name The name of the sitemap to get a URL for.
-	 * @return string the sitemap index url.
-	 */
-	public function get_sitemap_url( $name ) {
-		global $wp_rewrite;
-
-		if ( $name === 'index' ) {
-			$url = home_url( '/sitemap.xml' );
-
-			if ( ! $wp_rewrite->using_permalinks() ) {
-				$url = add_query_arg( 'sitemap', 'index', home_url( '/' ) );
-			}
-		} else {
-			$url = home_url( sprintf( '/sitemap-%1$s.xml', $name ) );
-
-			if ( ! $wp_rewrite->using_permalinks() ) {
-				$url = add_query_arg( 'sitemap', $name, home_url( '/' ) );
-			}
-		}
-
-		return $url;
-	}
 }

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -13,6 +13,7 @@ class Core_Sitemaps_Renderer {
 	 * Get the URL for a specific sitemap.
 	 *
 	 * @param string $name The name of the sitemap to get a URL for.
+	 *
 	 * @return string the sitemap index url.
 	 */
 	public function get_sitemap_url( $name ) {
@@ -27,6 +28,7 @@ class Core_Sitemaps_Renderer {
 		if ( ! $wp_rewrite->using_permalinks() ) {
 			$url = add_query_arg( 'sitemap', $name, home_url( '/' ) );
 		}
+
 		return $url;
 	}
 
@@ -41,7 +43,7 @@ class Core_Sitemaps_Renderer {
 
 		foreach ( $sitemaps as $link ) {
 			$sitemap = $sitemap_index->addChild( 'sitemap' );
-			$sitemap->addChild( 'loc', esc_url( $this->get_sitemap_url( $link->slug ) ) );
+			$sitemap->addChild( 'loc', esc_url( $this->get_sitemap_url( $link->name ) ) );
 			$sitemap->addChild( 'lastmod', '2004-10-01T18:23:17+00:00' );
 		}
 		echo $sitemap_index->asXML();

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -10,6 +10,27 @@
  */
 class Core_Sitemaps_Renderer {
 	/**
+	 * Get the URL for a specific sitemap.
+	 *
+	 * @param string $name The name of the sitemap to get a URL for.
+	 * @return string the sitemap index url.
+	 */
+	public function get_sitemap_url( $name ) {
+		global $wp_rewrite;
+
+		$home_url_append = '';
+		if ( 'index' !== $name ) {
+			$home_url_append = '-' . $name;
+		}
+		$url = home_url( sprintf( '/sitemap%1$s.xml', $home_url_append ) );
+
+		if ( ! $wp_rewrite->using_permalinks() ) {
+			$url = add_query_arg( 'sitemap', $name, home_url( '/' ) );
+		}
+		return $url;
+	}
+
+	/**
 	 * Render a sitemap index.
 	 *
 	 * @param array $sitemaps List of sitemaps, see \Core_Sitemaps_Registry::$sitemaps.
@@ -20,7 +41,7 @@ class Core_Sitemaps_Renderer {
 
 		foreach ( $sitemaps as $link ) {
 			$sitemap = $sitemap_index->addChild( 'sitemap' );
-			$sitemap->addChild( 'loc', esc_url( $link->slug ) );
+			$sitemap->addChild( 'loc', esc_url( $this->get_sitemap_url( $link->slug ) ) );
 			$sitemap->addChild( 'lastmod', '2004-10-01T18:23:17+00:00' );
 		}
 		echo $sitemap_index->asXML();

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -14,13 +14,13 @@ class Core_Sitemaps_Renderer {
 	 *
 	 * @param array $sitemaps List of sitemaps, see \Core_Sitemaps_Registry::$sitemaps.
 	 */
-	public function render_sitemapindex( $sitemaps ) {
+	public function render_index( $sitemaps ) {
 		header( 'Content-type: application/xml; charset=UTF-8' );
 		$sitemap_index = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8" ?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>' );
 
 		foreach ( $sitemaps as $link ) {
 			$sitemap = $sitemap_index->addChild( 'sitemap' );
-			$sitemap->addChild( 'loc', esc_url( $link['slug'] ) );
+			$sitemap->addChild( 'loc', esc_url( $link->slug ) );
 			$sitemap->addChild( 'lastmod', '2004-10-01T18:23:17+00:00' );
 		}
 		echo $sitemap_index->asXML();

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -11,53 +11,79 @@
  */
 class Core_Sitemaps {
 	/**
-	 * List of registered sitemap providers.
+	 * The main index of supported sitemaps.
 	 *
-	 * @var Core_Sitemaps_Provider[]
+	 * @var Core_Sitemaps_Index
 	 */
-	protected $providers;
+	public $index;
+
+	/**
+	 * The main registry of supported sitemaps.
+	 *
+	 * @var Core_Sitemaps_Registry
+	 */
+	public $registry;
+
 	/**
 	 * Core_Sitemaps constructor.
-	 * Register the registry and bootstrap registered providers.
-	 *
-	 * @uses apply_filters
 	 */
 	public function __construct() {
-		$registry = new Core_Sitemaps_Registry();
+		$this->index    = new Core_Sitemaps_Index();
+		$this->registry = new Core_Sitemaps_Registry();
+	}
 
-		// Index is not a post-type thus cannot be disabled.
-		// @link https://github.com/GoogleChromeLabs/wp-sitemaps/pull/42#discussion_r342517549 reasoning.
-		$index = new Core_Sitemaps_Index();
-		$index->set_registry( $registry );
-		$index->bootstrap();
+	/**
+	 * Initiate all sitemap functionality.
+	 *
+	 * @return void
+	 */
+	public function bootstrap() {
+		add_action( 'init', array( $this, 'setup_sitemaps_index' ) );
+		add_action( 'init', array( $this, 'register_sitemaps' ) );
+		add_action( 'init', array( $this, 'setup_sitemaps' ) );
+	}
 
+	/**
+	 * Set up the main sitemap index.
+	 */
+	public function setup_sitemaps_index() {
+		$this->index->bootstrap();
+	}
+
+	/**
+	 * Register and set up the functionality for all supported sitemaps.
+	 */
+	public function register_sitemaps() {
 		/**
-		 * Provides a 'core_sitemaps_register_providers' filter which contains a associated array of
-		 * Core_Sitemap_Provider instances to register, with the key passed into it's bootstrap($key) function.
+		 * Filters the list of registered sitemap providers.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param array $providers Array of Core_Sitemap_Provider objects.
 		 */
-		$this->providers = apply_filters(
-			'core_sitemaps_register_providers',
-			[
-				'posts' => new Core_Sitemaps_Posts(),
-				'pages' => new Core_Sitemaps_Pages(),
-			]
-		);
+		$providers = apply_filters( 'core_sitemaps_register_providers', array(
+			'posts' => new Core_Sitemaps_Posts(),
+			'pages' => new Core_Sitemaps_Pages(),
+		) );
 
-		foreach ( $this->providers as $key => $provider ) {
-			if ( $provider instanceof Core_Sitemaps_Provider ) {
-				$provider->set_registry( $registry );
-				$provider->bootstrap( $key );
-			}
+		// Register each supported provider.
+		foreach ( $providers as $provider ) {
+			$this->registry->add_sitemap( $provider->name, $provider );
 		}
 	}
 
 	/**
-	 * Get registered providers.
-	 * Useful for code that wants to call a method on all of the registered providers.
-	 *
-	 * @return Core_Sitemaps_Provider[]
+	 * Register and set up the functionality for all supported sitemaps.
 	 */
-	public function get_providers() {
-		return $this->providers;
+	public function setup_sitemaps() {
+		$sitemaps = $this->registry->get_sitemaps();
+
+		// Set up rewrites and rendering callbacks for each supported sitemap.
+		foreach ( $sitemaps as $sitemap ) {
+			add_rewrite_rule( $sitemap->route, 'index.php?sitemap=' . $sitemap->name, 'top' );
+			add_action( 'template_redirect', array( $sitemap, 'render_sitemap' ) );
+		}
 	}
+
+
 }

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -47,7 +47,7 @@ class Core_Sitemaps {
 	 * Set up the main sitemap index.
 	 */
 	public function setup_sitemaps_index() {
-		$this->index->bootstrap();
+		$this->index->setup_sitemap();
 	}
 
 	/**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Core sitemap public functions.
+ *
+ * @package Core_Sitemaps
+ */
+
+/**
+ * Get a list of URLs for all sitemaps.
+ *
+ * @return array $urls A list of sitemap URLs.
+ */
+function core_sitemaps_get_sitemaps() {
+	global $core_sitemaps;
+
+	$urls = $core_sitemaps->registry->get_sitemaps();
+
+	return $urls;
+}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -6,14 +6,14 @@
  */
 
 /**
- * Get a list of URLs for all sitemaps.
+ * Get a list of sitemaps.
  *
- * @return array $urls A list of sitemap URLs.
+ * @return array $sitemaps A list of registered sitemap providers.
  */
 function core_sitemaps_get_sitemaps() {
 	global $core_sitemaps;
 
-	$urls = $core_sitemaps->registry->get_sitemaps();
+	$sitemaps = $core_sitemaps->registry->get_sitemaps();
 
-	return $urls;
+	return $sitemaps;
 }


### PR DESCRIPTION
### Issue Number
This fixes #44.

### Description
This makes the Core_Sitemaps_Registry a property of the Core_Sitemaps class and moves the responsibility for registering sitemaps from each sitemap provider to the main Core_Sitemaps class. This allows each provider to expose the properties required for setting up and rendering sitemaps without needing to have any knowledge of the registry at all so we're not passing around as many objects between parts of the system.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
- [ ] Make sure to flush rewrite rules after checking out this branch.
- [ ] Visit /sitemap.xml to see the sitemap index including links to the two sitemaps for pages and posts (currently with incorrect URLs).
- [ ] Visit /sitemap-pages.xml to see the sitemap for pages.
- [ ] Visit /sitemap-posts.xml to see the sitemap for posts.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
