### PR TITLE
#23 Add Users sitemap

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -29,6 +29,7 @@ require_once __DIR__ . '/inc/class-sitemaps-pages.php';
 require_once __DIR__ . '/inc/class-sitemaps-posts.php';
 require_once __DIR__ . '/inc/class-sitemaps-registry.php';
 require_once __DIR__ . '/inc/class-sitemaps-renderer.php';
+require_once __DIR__ . '/inc/class-sitemaps-users.php';
 require_once __DIR__ . '/inc/functions.php';
 
 $core_sitemaps = new Core_Sitemaps();

--- a/inc/class-sitemaps-pages.php
+++ b/inc/class-sitemaps-pages.php
@@ -46,10 +46,14 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 		$sitemap = get_query_var( 'sitemap' );
 		$paged   = get_query_var( 'paged' );
 
+		if ( empty( $paged ) ) {
+			$paged = 1;
+		}
+
 		if ( 'pages' === $sitemap ) {
-			$content  = $this->get_content_per_page( $this->object_type, $paged );
+			$url_list  = $this->get_url_list( $this->object_type, $paged );
 			$renderer = new Core_Sitemaps_Renderer();
-			$renderer->render_urlset( $content );
+			$renderer->render_sitemap( $url_list );
 			exit;
 		}
 	}

--- a/inc/class-sitemaps-pages.php
+++ b/inc/class-sitemaps-pages.php
@@ -11,7 +11,6 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 	 * @var string
 	 */
 	protected $object_type = 'page';
-
 	/**
 	 * Sitemap name
 	 *
@@ -20,7 +19,6 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 	 * @var string
 	 */
 	public $name = 'pages';
-
 	/**
 	 * Sitemap route.
 	 *
@@ -29,7 +27,6 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 	 * @var string
 	 */
 	public $route = '^sitemap-pages\.xml$';
-
 	/**
 	 * Sitemap slug.
 	 *
@@ -51,7 +48,7 @@ class Core_Sitemaps_Pages extends Core_Sitemaps_Provider {
 		}
 
 		if ( 'pages' === $sitemap ) {
-			$url_list  = $this->get_url_list( $this->object_type, $paged );
+			$url_list = $this->get_url_list( $paged );
 			$renderer = new Core_Sitemaps_Renderer();
 			$renderer->render_sitemap( $url_list );
 			exit;

--- a/inc/class-sitemaps-posts.php
+++ b/inc/class-sitemaps-posts.php
@@ -46,10 +46,14 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 		$sitemap = get_query_var( 'sitemap' );
 		$paged   = get_query_var( 'paged' );
 
+		if ( empty( $paged ) ) {
+			$paged = 1;
+		}
+
 		if ( 'posts' === $sitemap ) {
-			$content  = $this->get_content_per_page( $this->object_type, $paged );
+			$url_list  = $this->get_url_list( $this->object_type, $paged );
 			$renderer = new Core_Sitemaps_Renderer();
-			$renderer->render_urlset( $content );
+			$renderer->render_sitemap( $url_list );
 			exit;
 		}
 	}

--- a/inc/class-sitemaps-posts.php
+++ b/inc/class-sitemaps-posts.php
@@ -51,7 +51,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 		}
 
 		if ( 'posts' === $sitemap ) {
-			$url_list  = $this->get_url_list( $this->object_type, $paged );
+			$url_list = $this->get_url_list( $paged );
 			$renderer = new Core_Sitemaps_Renderer();
 			$renderer->render_sitemap( $url_list );
 			exit;

--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -44,13 +44,13 @@ class Core_Sitemaps_Provider {
 	/**
 	 * Get a URL list for a post type sitemap.
 	 *
-	 * @param string $object_type Name of the object_type.
-	 * @param int    $page_num Page of results.
+	 * @param int $page_num Page of results.
 	 *
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $object_type, $page_num = 1 ) {
-		$query = new WP_Query( array(
+	public function get_url_list( $page_num ) {
+		$object_type = $this->object_type;
+		$query       = new WP_Query( array(
 			'orderby'        => 'ID',
 			'order'          => 'ASC',
 			'post_type'      => $object_type,

--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -46,24 +46,44 @@ class Core_Sitemaps_Provider {
 	public $slug = '';
 
 	/**
-	 * Get content for a page.
+	 * Get a URL list for a post type sitemap.
 	 *
 	 * @param string $object_type Name of the object_type.
-	 * @param int    $page_num Page of results.
-	 *
-	 * @return int[]|WP_Post[] Query result.
+	 * @param int    $page_num    Page of results.
+	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_content_per_page( $object_type, $page_num = 1 ) {
-		$query = new WP_Query();
+	public function get_url_list( $object_type, $page_num = 1 ) {
+		$query = new WP_Query( array(
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
+			'post_type'      => $object_type,
+			'posts_per_page' => CORE_SITEMAPS_POSTS_PER_PAGE,
+			'paged'          => $page_num,
+			'no_found_rows'  => true,
+		) );
 
-		return $query->query(
-			array(
-				'orderby'        => 'ID',
-				'order'          => 'ASC',
-				'post_type'      => $object_type,
-				'posts_per_page' => CORE_SITEMAPS_POSTS_PER_PAGE,
-				'paged'          => $page_num,
-			)
-		);
+		$posts = $query->get_posts();
+
+		$url_list = array();
+
+		foreach( $posts as $post ) {
+			$url_list[] = array(
+				'loc' => get_permalink( $post ),
+				'lastmod' => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
+				'priority' => '0.5',
+				'changefreq' => 'monthy',
+			);
+		}
+
+		/**
+		 * Filter the list of URLs for a sitemap before rendering.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param array  $url_list    List of URLs for a sitemap.
+		 * @param string $object_type Name of the post_type.
+		 * @param int    $page_num    Page of results.
+		 */
+		return apply_filters( 'core_sitemaps_post_url_list', $url_list, $object_type, $page_num );
 	}
 }

--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -66,7 +66,7 @@ class Core_Sitemaps_Provider {
 
 		$url_list = array();
 
-		foreach( $posts as $post ) {
+		foreach ( $posts as $post ) {
 			$url_list[] = array(
 				'loc' => get_permalink( $post ),
 				'lastmod' => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),

--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -10,14 +10,12 @@
  * Class Core_Sitemaps_Provider
  */
 class Core_Sitemaps_Provider {
-
 	/**
 	 * Post type name.
 	 *
 	 * @var string
 	 */
 	protected $object_type = '';
-
 	/**
 	 * Sitemap name
 	 *
@@ -26,7 +24,6 @@ class Core_Sitemaps_Provider {
 	 * @var string
 	 */
 	public $name = '';
-
 	/**
 	 * Sitemap route
 	 *
@@ -35,7 +32,6 @@ class Core_Sitemaps_Provider {
 	 * @var string
 	 */
 	public $route = '';
-
 	/**
 	 * Sitemap slug
 	 *
@@ -49,7 +45,8 @@ class Core_Sitemaps_Provider {
 	 * Get a URL list for a post type sitemap.
 	 *
 	 * @param string $object_type Name of the object_type.
-	 * @param int    $page_num    Page of results.
+	 * @param int    $page_num Page of results.
+	 *
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
 	public function get_url_list( $object_type, $page_num = 1 ) {
@@ -68,21 +65,19 @@ class Core_Sitemaps_Provider {
 
 		foreach ( $posts as $post ) {
 			$url_list[] = array(
-				'loc' => get_permalink( $post ),
+				'loc'     => get_permalink( $post ),
 				'lastmod' => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
-				'priority' => '0.5',
-				'changefreq' => 'monthy',
 			);
 		}
 
 		/**
 		 * Filter the list of URLs for a sitemap before rendering.
 		 *
-		 * @since 0.1.0
-		 *
-		 * @param array  $url_list    List of URLs for a sitemap.
+		 * @param array  $url_list List of URLs for a sitemap.
 		 * @param string $object_type Name of the post_type.
-		 * @param int    $page_num    Page of results.
+		 * @param int    $page_num Page of results.
+		 *
+		 * @since 0.1.0
 		 */
 		return apply_filters( 'core_sitemaps_post_url_list', $url_list, $object_type, $page_num );
 	}

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -27,21 +27,22 @@ class Core_Sitemaps_Renderer {
 	}
 
 	/**
-	 * Render a sitemap urlset.
+	 * Render a sitemap.
 	 *
-	 * @param WP_Post[] $content List of WP_Post objects.
+	 * @param array $url_list A list of URLs for a sitemap.
 	 */
-	public function render_urlset( $content ) {
+	public function render_sitemap( $url_list ) {
 		header( 'Content-type: application/xml; charset=UTF-8' );
 		$urlset = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8" ?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>' );
 
-		foreach ( $content as $post ) {
+		foreach ( $url_list as $url_item ) {
 			$url = $urlset->addChild( 'url' );
-			$url->addChild( 'loc', esc_url( get_permalink( $post ) ) );
-			$url->addChild( 'lastmod', mysql2date( DATE_W3C, $post->post_modified_gmt, false ) );
-			$url->addChild( 'priority', '0.5' );
-			$url->addChild( 'changefreq', 'monthly' );
+			$url->addChild( 'loc', esc_url( $url_item['loc'] ) );
+			$url->addChild( 'lastmod', esc_attr( $url_item['lastmod'] ) );
+			$url->addChild( 'priority', esc_attr( $url_item['priority'] ) );
+			$url->addChild( 'changefreq', esc_attr( $url_item['changefreq' ] ) );
 		}
+
 		echo $urlset->asXML();
 	}
 }

--- a/inc/class-sitemaps-renderer.php
+++ b/inc/class-sitemaps-renderer.php
@@ -39,8 +39,6 @@ class Core_Sitemaps_Renderer {
 			$url = $urlset->addChild( 'url' );
 			$url->addChild( 'loc', esc_url( $url_item['loc'] ) );
 			$url->addChild( 'lastmod', esc_attr( $url_item['lastmod'] ) );
-			$url->addChild( 'priority', esc_attr( $url_item['priority'] ) );
-			$url->addChild( 'changefreq', esc_attr( $url_item['changefreq' ] ) );
 		}
 
 		echo $urlset->asXML();

--- a/inc/class-sitemaps-users.php
+++ b/inc/class-sitemaps-users.php
@@ -71,7 +71,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 
 		$url_list = array();
 
-		foreach( $users as $user ) {
+		foreach ( $users as $user ) {
 			$last_modified = get_posts( array(
 				'author'        => $user->ID,
 				'orderby'       => 'date',
@@ -97,7 +97,6 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 		 * @param int    $page_num    Page of results.
 		 */
 		return apply_filters( 'core_sitemaps_users_url_list', $url_list, $object_type, $page_num );
-
 	}
 
 	/**

--- a/inc/class-sitemaps-users.php
+++ b/inc/class-sitemaps-users.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * The Core_Sitemaps_Users sitemap provider.
+ *
+ * This class extends Core_Sitemaps_Provider to support sitemaps for user pages in WordPress.
+ *
+ * @package Core_Sitemaps
+ */
+
+/**
+ * Class Core_Sitemaps_Users
+ */
+class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
+
+	/**
+	 * Object type name.
+	 *
+	 * @var string
+	 */
+	protected $object_type = 'user';
+
+	/**
+	 * Sitemap name.
+	 *
+	 * Used for building sitemap URLs.
+	 *
+	 * @var string
+	 */
+	public $name = 'users';
+
+	/**
+	 * Sitemap route.
+	 *
+	 * Regex pattern used when building the route for a sitemap.
+	 *
+	 * @var string
+	 */
+	public $route = '^sitemap-users-?([0-9]+)?\.xml$';
+
+	/**
+	 * Sitemap slug.
+	 *
+	 * Used for building sitemap URLs.
+	 *
+	 * @var string
+	 */
+	public $slug = 'users';
+
+	/**
+	 * Get a URL list for a user sitemap.
+	 *
+	 * @param string $object_type Name of the object_type.
+	 * @param int    $page_num Page of results.
+	 * @return array $url_list List of URLs for a sitemap.
+	 */
+	public function get_url_list( $object_type, $page_num = 1 ) {
+		$public_post_types = get_post_types( array(
+			'public' => true,
+		) );
+
+		// We're not supporting sitemaps for author pages for attachments.
+		unset( $public_post_types['attachment'] ) ;
+
+		$query = new WP_User_Query( array(
+			'has_published_posts' => array_keys( $public_post_types ),
+			'number'              => CORE_SITEMAPS_POSTS_PER_PAGE,
+			'paged'               => absint( $page_num ),
+		) );
+
+		$users = $query->get_results();
+
+		$url_list = array();
+
+		foreach( $users as $user ) {
+			$last_modified = get_posts( array(
+				'author'        => $user->ID,
+				'orderby'       => 'date',
+				'numberposts'   => 1,
+				'no_found_rows' => true,
+			) );
+
+			$url_list[] = array(
+				'loc' => get_author_posts_url( $user->ID ),
+				'lastmod' => mysql2date( DATE_W3C, $last_modified[0]->post_modified_gmt, false ),
+				'priority' => '0.3',
+				'changefreq' => 'daily',
+			);
+		}
+
+		/**
+		 * Filter the list of URLs for a sitemap before rendering.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param array  $url_list    List of URLs for a sitemap.
+		 * @param string $object_type Name of the post_type.
+		 * @param int    $page_num    Page of results.
+		 */
+		return apply_filters( 'core_sitemaps_users_url_list', $url_list, $object_type, $page_num );
+
+	}
+
+	/**
+	 * Produce XML to output.
+	 */
+	public function render_sitemap() {
+		$sitemap = get_query_var( 'sitemap' );
+		$paged   = get_query_var( 'paged' );
+
+		if ( empty( $paged ) ) {
+			$paged = 1;
+		}
+
+		if ( 'users' === $sitemap ) {
+			$url_list  = $this->get_url_list( 'users', $paged );
+			$renderer = new Core_Sitemaps_Renderer();
+			$renderer->render_sitemap( $url_list );
+			exit;
+		}
+	}
+
+}

--- a/inc/class-sitemaps-users.php
+++ b/inc/class-sitemaps-users.php
@@ -45,12 +45,12 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	/**
 	 * Get a URL list for a user sitemap.
 	 *
-	 * @param string $object_type Name of the object_type.
-	 * @param int    $page_num Page of results.
+	 * @param int $page_num Page of results.
 	 *
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $object_type, $page_num = 1 ) {
+	public function get_url_list( $page_num ) {
+		$object_type       = $this->object_type;
 		$public_post_types = get_post_types( array(
 			'public' => true,
 		) );
@@ -107,7 +107,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 		}
 
 		if ( 'users' === $sitemap ) {
-			$url_list = $this->get_url_list( 'users', $paged );
+			$url_list = $this->get_url_list( $paged );
 			$renderer = new Core_Sitemaps_Renderer();
 			$renderer->render_sitemap( $url_list );
 			exit;

--- a/inc/class-sitemaps-users.php
+++ b/inc/class-sitemaps-users.php
@@ -11,14 +11,12 @@
  * Class Core_Sitemaps_Users
  */
 class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
-
 	/**
 	 * Object type name.
 	 *
 	 * @var string
 	 */
 	protected $object_type = 'user';
-
 	/**
 	 * Sitemap name.
 	 *
@@ -27,7 +25,6 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * @var string
 	 */
 	public $name = 'users';
-
 	/**
 	 * Sitemap route.
 	 *
@@ -36,7 +33,6 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * @var string
 	 */
 	public $route = '^sitemap-users-?([0-9]+)?\.xml$';
-
 	/**
 	 * Sitemap slug.
 	 *
@@ -51,6 +47,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 *
 	 * @param string $object_type Name of the object_type.
 	 * @param int    $page_num Page of results.
+	 *
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
 	public function get_url_list( $object_type, $page_num = 1 ) {
@@ -59,7 +56,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 		) );
 
 		// We're not supporting sitemaps for author pages for attachments.
-		unset( $public_post_types['attachment'] ) ;
+		unset( $public_post_types['attachment'] );
 
 		$query = new WP_User_Query( array(
 			'has_published_posts' => array_keys( $public_post_types ),
@@ -80,21 +77,20 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 			) );
 
 			$url_list[] = array(
-				'loc' => get_author_posts_url( $user->ID ),
+				'loc'     => get_author_posts_url( $user->ID ),
 				'lastmod' => mysql2date( DATE_W3C, $last_modified[0]->post_modified_gmt, false ),
-				'priority' => '0.3',
-				'changefreq' => 'daily',
 			);
 		}
 
 		/**
 		 * Filter the list of URLs for a sitemap before rendering.
 		 *
+		 * @param array  $url_list List of URLs for a sitemap.
+		 * @param string $object_type Name of the post_type.
+		 * @param int    $page_num Page of results.
+		 *
 		 * @since 0.1.0
 		 *
-		 * @param array  $url_list    List of URLs for a sitemap.
-		 * @param string $object_type Name of the post_type.
-		 * @param int    $page_num    Page of results.
 		 */
 		return apply_filters( 'core_sitemaps_users_url_list', $url_list, $object_type, $page_num );
 	}
@@ -111,11 +107,10 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 		}
 
 		if ( 'users' === $sitemap ) {
-			$url_list  = $this->get_url_list( 'users', $paged );
+			$url_list = $this->get_url_list( 'users', $paged );
 			$renderer = new Core_Sitemaps_Renderer();
 			$renderer->render_sitemap( $url_list );
 			exit;
 		}
 	}
-
 }

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -64,6 +64,7 @@ class Core_Sitemaps {
 		$providers = apply_filters( 'core_sitemaps_register_providers', array(
 			'posts' => new Core_Sitemaps_Posts(),
 			'pages' => new Core_Sitemaps_Pages(),
+			'users' => new Core_Sitemaps_Users(),
 		) );
 
 		// Register each supported provider.
@@ -80,7 +81,7 @@ class Core_Sitemaps {
 
 		// Set up rewrites and rendering callbacks for each supported sitemap.
 		foreach ( $sitemaps as $sitemap ) {
-			add_rewrite_rule( $sitemap->route, 'index.php?sitemap=' . $sitemap->name, 'top' );
+			add_rewrite_rule( $sitemap->route, 'index.php?sitemap=' . $sitemap->name . '&paged=$matches[1]', 'top' );
 			add_action( 'template_redirect', array( $sitemap, 'render_sitemap' ) );
 		}
 	}


### PR DESCRIPTION
### Issue Number
This fixes #23. And is blocked by #44.

### Description
This adds a `Core_Sitemaps_Users` sitemap provider based on the registry pattern demonstrated in #44. This provider defines the rewrite regex and query functionality to render user sitemap pages.

This also updates the `Core_Sitemaps_Renderer` so that the render function accepts a prepared url_list so each sitemap provider can query the appropriate object type and handle its own implementation for building out the list of urls for a sitemap urlset. All existing providers have been updated to make use of the same rendering pattern.

### Screenshots (before and after if applicable)
If your PR includes visual changes include before and after screenshots showing the change.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
1. Flush permalinks
2. Visit /sitemap-users.xml to see a users sitemap.
3. Visit /sitemap-users-2.xml to see the second page of users if there are more than 2000 users with published posts.

### Acceptance criteris
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
