### PR TITLE
Improve post query performance.

### DIFF
--- a/inc/class-sitemaps-provider.php
+++ b/inc/class-sitemaps-provider.php
@@ -54,11 +54,14 @@ class Core_Sitemaps_Provider {
 
 		return $query->query(
 			array(
-				'orderby'        => 'ID',
-				'order'          => 'ASC',
-				'post_type'      => $object_type,
-				'posts_per_page' => CORE_SITEMAPS_POSTS_PER_PAGE,
-				'paged'          => $page_num,
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+				'post_type'              => $object_type,
+				'posts_per_page'         => CORE_SITEMAPS_POSTS_PER_PAGE,
+				'paged'                  => $page_num,
+				'no_found_rows'          => true,
+				'update_post_term_cache' => false,
+				'update_post_meta_cache' => false,
 			)
 		);
 	}


### PR DESCRIPTION
### Description
This adds three new arguments to the query in `Core_Sitemaps_Provider::get_content_per_page()` to speed up the raw query time:

* `no_found_rows => true` - keeps WP from doing an initial query to count how many posts are in the database for calculating pagination.
* `update_post_term_cache => false` - keeps WP from running an addtional query to warm the post term cache.
* `update_post_meta_cache => false` - keeps WP from running an addtional query to warm the post meta cache.

Adding these arguments reduced the raw query time of a sitemap page on my local environment, containing ~260k posts, from ~2.5 seconds down to ~1.5 seconds.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves an existing feature).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Describe the tests required to verify your changes.
Provide instructions so the PR Tester can check functionality and also list any relevant details and / or dependancies required for your tests.

### Acceptance criteris
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
