### PR TITLE
Flushing rewrite rules QOL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,11 @@
       "@setup"
     ],
     "setup": [
-      "@composer run-script --list"
+      "@composer run-script --list",
+      "@local:flush"
+    ],
+    "local:flush": [
+      "wp @local rewrite flush"
     ],
     "local:tests": [
       "@test:phpcs",
@@ -46,6 +50,7 @@
   },
   "scripts-descriptions": {
     "setup": "Sets up the development environment.",
+    "local:flush": "Flush rewrite rules (local)",
     "local:phpunit": "Run PHPUnit tests (local)",
     "test:phpunit": "Run PHPUnit tests.",
     "test:phpcs": "Runs the PHP code sniffer."

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
       "@setup"
     ],
     "setup": [
-      "@composer run-script --list",
-      "@local:flush"
+      "@composer run-script --list"
     ],
     "local:flush": [
       "wp @local rewrite flush"

--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -2,10 +2,10 @@
 /**
  * Core Sitemaps Plugin.
  *
- * @package Core_Sitemaps
- * @copyright 2019 The Core Sitemaps Contributors
- * @license   GNU General Public License, version 2
- * @link      https://github.com/GoogleChromeLabs/wp-sitemaps
+ * @package         Core_Sitemaps
+ * @copyright       2019 The Core Sitemaps Contributors
+ * @license         GNU General Public License, version 2
+ * @link            https://github.com/GoogleChromeLabs/wp-sitemaps
  *
  * Plugin Name:     Core Sitemaps
  * Plugin URI:      https://github.com/GoogleChromeLabs/wp-sitemaps
@@ -19,8 +19,9 @@
  * @package         Core_Sitemaps
  */
 
-const CORE_SITEMAPS_POSTS_PER_PAGE = 2000;
-const CORE_SITEMAPS_MAX_URLS       = 50000;
+const CORE_SITEMAPS_POSTS_PER_PAGE  = 2000;
+const CORE_SITEMAPS_MAX_URLS        = 50000;
+const CORE_SITEMAPS_REWRITE_VERSION = '2019111201';
 
 require_once __DIR__ . '/inc/class-sitemaps.php';
 require_once __DIR__ . '/inc/class-sitemaps-provider.php';

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -61,7 +61,6 @@ class Core_Sitemaps {
 		 * @since 0.1.0
 		 *
 		 * @param array $providers Array of Core_Sitemap_Provider objects.
-		 *
 		 */
 		$providers = apply_filters(
 			'core_sitemaps_register_providers',

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -58,8 +58,9 @@ class Core_Sitemaps {
 		/**
 		 * Filters the list of registered sitemap providers.
 		 *
-		 * @param array $providers Array of Core_Sitemap_Provider objects.
 		 * @since 0.1.0
+		 *
+		 * @param array $providers Array of Core_Sitemap_Provider objects.
 		 *
 		 */
 		$providers = apply_filters( 'core_sitemaps_register_providers', array(

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -41,6 +41,7 @@ class Core_Sitemaps {
 		add_action( 'init', array( $this, 'setup_sitemaps_index' ) );
 		add_action( 'init', array( $this, 'register_sitemaps' ) );
 		add_action( 'init', array( $this, 'setup_sitemaps' ) );
+		add_action( 'plugins_loaded', array( $this, 'maybe_flush_rewrites' ) );
 	}
 
 	/**
@@ -57,9 +58,9 @@ class Core_Sitemaps {
 		/**
 		 * Filters the list of registered sitemap providers.
 		 *
+		 * @param array $providers Array of Core_Sitemap_Provider objects.
 		 * @since 0.1.0
 		 *
-		 * @param array $providers Array of Core_Sitemap_Provider objects.
 		 */
 		$providers = apply_filters( 'core_sitemaps_register_providers', array(
 			'posts'      => new Core_Sitemaps_Posts(),
@@ -84,6 +85,15 @@ class Core_Sitemaps {
 		foreach ( $sitemaps as $sitemap ) {
 			add_rewrite_rule( $sitemap->route, 'index.php?sitemap=' . $sitemap->name . '&paged=$matches[1]', 'top' );
 			add_action( 'template_redirect', array( $sitemap, 'render_sitemap' ) );
+		}
+	}
+
+	/**
+	 * Flush rewrite rules if developers updated them.
+	 */
+	public function maybe_flush_rewrites() {
+		if ( update_option( 'core_sitemaps_rewrite_version', CORE_SITEMAPS_REWRITE_VERSION ) ) {
+			flush_rewrite_rules( false );
 		}
 	}
 }


### PR DESCRIPTION
### Description
Adds a new script for flushing rewrite rules manually `composer run local:flush`, and code to flush the rewrites rule on the request if the constant has been updated, for example after adding a provider.


### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Set a breakpoint on the method, or run the composer command.

### Acceptance criteris
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [x] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
