### PR TITLE
[WIP] Add initial implementation for saving sitemaps to buckets.

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -23,6 +23,7 @@ const CORE_SITEMAPS_POSTS_PER_PAGE = 2000;
 const CORE_SITEMAPS_MAX_URLS       = 50000;
 
 require_once __DIR__ . '/inc/class-sitemaps.php';
+require_once __DIR__ . '/inc/class-sitemaps-buckets.php';
 require_once __DIR__ . '/inc/class-sitemaps-provider.php';
 require_once __DIR__ . '/inc/class-sitemaps-index.php';
 require_once __DIR__ . '/inc/class-sitemaps-pages.php';

--- a/inc/class-sitemaps-buckets.php
+++ b/inc/class-sitemaps-buckets.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Core Sitemaps: Core_Sitemaps_Buckets class
+ *
+ * @package Core_Sitemaps
+ * @since 0.1.0
+ */
+
+/**
+ * Core class to manage sitemap buckets.
+ *
+ * @since 0.1.0
+ */
+class Core_Sitemaps_Buckets {
+
+	/**
+	 * Custom post type key.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE = 'core_sitemaps_bucket';
+
+	/**
+	 * Register the sitemap buckets custom post type.
+	 */
+	public function register_bucket_post_type() {
+		// Post type arguments for our custom post type.
+		$args = array(
+			'labels'             => array(
+				'name'          => _x( 'Sitemap Buckets', 'Post type general name', 'core-sitemaps' ),
+				'singular_name' => _x( 'Sitemap Bucket', 'Post type singular name', 'core-sitemaps' ),
+			),
+			'public'             => false,
+			'capability_type'    => 'post',
+			'has_archive'        => false,
+		);
+
+		register_post_type( self::POST_TYPE, $args );
+	}
+
+	/**
+	 * Helper to get a specific bucket object.
+	 *
+	 * @param string  $object_type    Main type of object stored in the bucket.
+	 * @param string  $object_subtype Object subtype for a bucket, e.g. post_type.
+	 * @param integer $page_num       The page number of the bucket being requested.
+	 * @return WP_Post|false A WP_Post object if found. False if none found or buckets not in use.
+	 */
+	public function get_bucket( $object_type, $object_subtype, $page_num ) {
+		/**
+		 * Filter the use of bucket caching.
+		 *
+		 * @param bool Whether buckets are in use. Default true.
+		 */
+		$use_buckets = apply_filters( 'core_sitemaps_use_buckets', true );
+
+		if ( ! $use_buckets ) {
+			return false;
+		}
+
+		$bucket_name = $this->get_bucket_name( $object_type, $object_subtype, $page_num );
+
+		$query_args = array(
+			'post_type' => self::POST_TYPE,
+			'post_name' => $bucket_name,
+			'posts_per_page' => 1,
+			'no_found_rows' => true,
+		);
+
+		$buckets = get_posts( $query_args );
+
+		if ( empty( $buckets ) ) {
+			return false;
+		}
+
+		return $buckets[0];
+	}
+
+	/**
+	 * Helper to save a specific bucket object.
+	 *
+	 * @param string  $object_type    Main type of object stored in the bucket.
+	 * @param string  $object_subtype Object subtype for a bucket, e.g. post_type.
+	 * @param integer $page_num       The page number of the bucket being requested.
+	 * @param array   $url_list       A list of url entry data for a sitemap.
+	 * @return int|WP_Error The value 0 or WP_Error on failure. The post ID on success.
+	 */
+	public function save_bucket( $object_type, $object_subtype, $page_num, $url_list ) {
+		/**
+		 * Documented in Core_Sitemaps_Buckets::get_bucket();
+		 */
+		$use_buckets = apply_filters( 'core_sitemaps_use_buckets', true );
+
+		if ( ! $use_buckets ) {
+			return 0;
+		}
+
+		$bucket = core_sitemaps_get_bucket( $object_type, $object_subtype, $page_num, $url_list );
+
+		// Sort the url_list by ID.
+		ksort( $url_list );
+
+		// Prepare bucket metadata.
+		$bucket_meta = array(
+			'count'  => count( $url_list ),
+			'min_ID' => key( array_slice( $url_list, 0, 1, true) ),
+			'max_ID' => key( array_slice( $url_list, -1, 1, true) ),
+		);
+
+		if ( $bucket ) {
+			return wp_update_post(
+				array(
+					'ID'           => $bucket->ID,
+					'post_content' => json_encode( $url_list ),
+					'meta_input'   => array(
+						'core_sitemap_bucket_meta' => $bucket_meta,
+					),
+				)
+			);
+		}
+
+		$bucket_name = $this->get_bucket_name( $object_type, $object_subtype, $page_num );
+
+		return wp_insert_post(
+			array(
+				'post_type'    => self::POST_TYPE,
+				'post_name'    => $bucket_name,
+				'post_content' => json_encode( $url_list ),
+				'post_status'  => 'publish',
+				'meta_input'   => array(
+					'core_sitemap_bucket_meta' => $bucket_meta,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Helper function to generate a bucket name.
+	 *
+	 * @param string  $object_type    Main type of object stored in the bucket.
+	 * @param string  $object_subtype Object subtype for a bucket, e.g. post_type.
+	 * @param integer $page_num       The page number of the bucket being requested.
+	 * @return string The post title for a sitemap bucket.
+	 */
+	public function get_bucket_name( $object_type, $object_subtype, $page_num ) {
+		$bucket_name = 'sitemap-' . $object_type;
+
+		if ( ! empty( $object_subtype ) ) {
+			$bucket_name = $bucket_name . '-' . $object_subtype;
+		}
+
+		if ( ! empty( $page_num ) ) {
+			$bucket_name = $bucket_name . '-' . $page_num;
+		}
+
+		return $bucket_name;
+	}
+}

--- a/inc/class-sitemaps.php
+++ b/inc/class-sitemaps.php
@@ -11,6 +11,13 @@
  */
 class Core_Sitemaps {
 	/**
+	 * Core Sitemaps bucket class.
+	 *
+	 * @var Core_Sitemaps_Buckets
+	 */
+	public $buckets;
+
+	/**
 	 * The main index of supported sitemaps.
 	 *
 	 * @var Core_Sitemaps_Index
@@ -28,6 +35,7 @@ class Core_Sitemaps {
 	 * Core_Sitemaps constructor.
 	 */
 	public function __construct() {
+		$this->buckets  = new Core_Sitemaps_Buckets();
 		$this->index    = new Core_Sitemaps_Index();
 		$this->registry = new Core_Sitemaps_Registry();
 	}
@@ -38,16 +46,10 @@ class Core_Sitemaps {
 	 * @return void
 	 */
 	public function bootstrap() {
-		add_action( 'init', array( $this, 'setup_sitemaps_index' ) );
+		add_action( 'init', array( $this->buckets, 'register_bucket_post_type' ) );
+		add_action( 'init', array( $this->index, 'setup_sitemap' ) );
 		add_action( 'init', array( $this, 'register_sitemaps' ) );
 		add_action( 'init', array( $this, 'setup_sitemaps' ) );
-	}
-
-	/**
-	 * Set up the main sitemap index.
-	 */
-	public function setup_sitemaps_index() {
-		$this->index->setup_sitemap();
 	}
 
 	/**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -17,3 +17,32 @@ function core_sitemaps_get_sitemaps() {
 
 	return $sitemaps;
 }
+
+/**
+ * Helper to get a specific bucket object.
+ *
+ * @param string  $object_type    Main type of object stored in the bucket.
+ * @param string  $object_subtype Object subtype for a bucket, e.g. post_type.
+ * @param integer $page_num       The page number of the bucket being requested.
+ * @return WP_Post|false A WP_Post object if found. False if none found or buckets not in use.
+ */
+function core_sitemaps_get_bucket( $object_type, $object_subtype, $page_num ) {
+	global $core_sitemaps;
+
+	return $core_sitemaps->buckets->get_bucket( $object_type, $object_subtype, $page_num );
+}
+
+/**
+ * Helper to save a specific bucket object.
+ *
+ * @param string  $object_type    Main type of object stored in the bucket.
+ * @param string  $object_subtype Object subtype for a bucket, e.g. post_type.
+ * @param integer $page_num       The page number of the bucket being requested.
+ * @param array   $url_list       A list of url entry data for a sitemap.
+ * @return int|WP_Error The value 0 or WP_Error on failure. The post ID on success.
+ */
+function core_sitemaps_save_bucket( $object_type, $object_subtype, $page_num, $url_list ) {
+	global $core_sitemaps;
+
+	return $core_sitemaps->buckets->save_bucket( $object_type, $object_subtype, $page_num, $url_list );
+}


### PR DESCRIPTION
### Issue Number
This is a work in progress branch that will fix #39.

### Description
- Add a Core_Sitemaps_Buckets class for controlling bucket functionality.
- Register a new core_sitemap_bucket post type for storing sitemap data.
- Add helper functions for saving/getting bucket data to inc/functions.php
- Update the users sitemap provider to use the bucket system for storing sitemap data.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Describe the tests required to verify your changes.
Provide instructions so the PR Tester can check functionality and also list any relevant details and / or dependancies required for your tests.

### Acceptance criteria
- [ ] My code follows WordPress coding standards.
- [ ] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
