### PR TITLE
Fix flush hook.

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -25,7 +25,7 @@
 
 const CORE_SITEMAPS_POSTS_PER_PAGE  = 2000;
 const CORE_SITEMAPS_MAX_URLS        = 50000;
-const CORE_SITEMAPS_REWRITE_VERSION = '2019111201';
+const CORE_SITEMAPS_REWRITE_VERSION = '2019-11-13a';
 
 require_once __DIR__ . '/inc/class-core-sitemaps.php';
 require_once __DIR__ . '/inc/class-core-sitemaps-provider.php';

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -41,7 +41,7 @@ class Core_Sitemaps {
 		add_action( 'init', array( $this, 'setup_sitemaps_index' ) );
 		add_action( 'init', array( $this, 'register_sitemaps' ) );
 		add_action( 'init', array( $this, 'setup_sitemaps' ) );
-		add_action( 'plugins_loaded', array( $this, 'maybe_flush_rewrites' ) );
+		add_action( 'wp_loaded', array( $this, 'maybe_flush_rewrites' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Description
In some cases flushing caused an exception to be thrown: `Call to a member function flush_rules() on null` as the rewrite rule flushing was attached to a suboptimal hook.

### Type of change
Please select the relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Set a breakpoint on content/plugins/core-sitemaps/inc/class-core-sitemaps.php:100 then change the constant, verify the function is called and the page loads correctly.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [x] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
