### PR TITLE
Remove unused variable from taxonomies provider.

### DIFF
--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -61,13 +61,12 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
 	public function get_url_list( $page_num ) {
-		$type = $this->sub_type; // Find the query_var for sub_type.
+		// Find the query_var for sub_type.
+		$type = $this->sub_type;
+
 		if ( empty( $type ) ) {
 			return;
 		}
-
-		// Get all of the taxonomies that are registered.
-		$taxonomies = $this->get_object_sub_types();
 
 		$url_list = array();
 


### PR DESCRIPTION
### Issue Number
This is a followup to #62.

### Description
This removes an unused `$taxonomies` variable in `Core_Sitemaps_Taxonomies::get_url_list()` that was left over after refactoring and includes some inline docs adjustments.

### Type of change
Please select the relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
