### PR TITLE
Feature/index registration mk2

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -12,6 +12,7 @@
  * @copyright       2019 The Core Sitemaps Contributors
  * @license         GNU General Public License, version 2
  * @link            https://github.com/GoogleChromeLabs/wp-sitemaps
+ *
  * Plugin Name:     Core Sitemaps
  * Plugin URI:      https://github.com/GoogleChromeLabs/wp-sitemaps
  * Description:     A feature plugin to integrate basic XML Sitemaps in WordPress Core

--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -12,7 +12,6 @@
  * @copyright       2019 The Core Sitemaps Contributors
  * @license         GNU General Public License, version 2
  * @link            https://github.com/GoogleChromeLabs/wp-sitemaps
- *
  * Plugin Name:     Core Sitemaps
  * Plugin URI:      https://github.com/GoogleChromeLabs/wp-sitemaps
  * Description:     A feature plugin to integrate basic XML Sitemaps in WordPress Core
@@ -25,7 +24,7 @@
 
 const CORE_SITEMAPS_POSTS_PER_PAGE  = 2000;
 const CORE_SITEMAPS_MAX_URLS        = 50000;
-const CORE_SITEMAPS_REWRITE_VERSION = '20191113c';
+const CORE_SITEMAPS_REWRITE_VERSION = '2019-11-15a';
 
 require_once __DIR__ . '/inc/class-core-sitemaps.php';
 require_once __DIR__ . '/inc/class-core-sitemaps-provider.php';

--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -71,7 +71,7 @@ class Core_Sitemaps_Index {
 
 		if ( 'index' === $sitemap_index ) {
 			$sitemaps = core_sitemaps_get_sitemaps();
-			$this->renderer->render_index( $sitemaps );
+			$this->renderer->render_index( array_keys( $sitemaps ) );
 			exit;
 		}
 	}

--- a/inc/class-core-sitemaps-posts.php
+++ b/inc/class-core-sitemaps-posts.php
@@ -39,8 +39,10 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 			if ( ! isset( $sub_types[ $sub_type ] ) ) {
 				// Force empty result set.
 				$paged = CORE_SITEMAPS_MAX_URLS + 1;
+				// TODO does not deal with the problem.
 			}
 
+			// TODO doesn't work if the if statement doesn't match.
 			$this->sub_type = $sub_types[ $sub_type ]->name;
 
 			$url_list = $this->get_url_list( $paged );

--- a/inc/class-core-sitemaps-posts.php
+++ b/inc/class-core-sitemaps-posts.php
@@ -38,12 +38,11 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 
 			$sub_types = $this->get_object_sub_types();
 
-			if ( ! isset( $sub_types[ $sub_type ] ) ) {
-				// Invalid sub type.
+			if ( ! isset( $sub_types[ $sub_type ] ) || $paged > $this->max_num_pages( $sub_type ) ) {
+				// Invalid sub type or out of range pagination.
 				$wp_query->set_404();
 				status_header( 404 );
 
-				return;
 			}
 
 			$this->sub_type = $sub_types[ $sub_type ]->name;

--- a/inc/class-core-sitemaps-posts.php
+++ b/inc/class-core-sitemaps-posts.php
@@ -82,20 +82,4 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	public function rewrite_query() {
 		return 'index.php?sitemap=' . $this->slug . '&sub_type=$matches[1]&paged=$matches[2]';
 	}
-
-	public function get_sitemaps() {
-		$sitemaps = array();
-
-		foreach ( $this->get_object_sub_types() as $type ) {
-			$query = $this->index_query( $type->name );
-
-			$total = isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
-			for ( $i = 1; $i <= $total; $i ++ ) {
-				$slug       = implode( '-', array_filter( array( $this->slug, $type->name, (string) $i ) ) );
-				$sitemaps[] = $slug;
-			}
-		}
-
-		return $sitemaps;
-	}
 }

--- a/inc/class-core-sitemaps-posts.php
+++ b/inc/class-core-sitemaps-posts.php
@@ -38,12 +38,10 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 
 			$sub_types = $this->get_object_sub_types();
 
-			if ( ! isset( $sub_types[ $sub_type ] ) ) {
-				// Invalid sub type.
+			if ( ! isset( $sub_types[ $sub_type ] ) || $paged > $this->max_num_pages( $sub_type ) ) {
+				// Invalid sub type or out of range pagination.
 				$wp_query->set_404();
 				status_header( 404 );
-
-				return;
 			}
 
 			$this->sub_type = $sub_types[ $sub_type ]->name;

--- a/inc/class-core-sitemaps-posts.php
+++ b/inc/class-core-sitemaps-posts.php
@@ -25,8 +25,6 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	 * @noinspection PhpUnused
 	 */
 	public function render_sitemap() {
-		global $wp_query;
-
 		$sitemap  = get_query_var( 'sitemap' );
 		$sub_type = get_query_var( 'sub_type' );
 		$paged    = get_query_var( 'paged' );
@@ -38,10 +36,9 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 
 			$sub_types = $this->get_object_sub_types();
 
-			if ( ! isset( $sub_types[ $sub_type ] ) || $paged > $this->max_num_pages( $sub_type ) ) {
-				// Invalid sub type or out of range pagination.
-				$wp_query->set_404();
-				status_header( 404 );
+			if ( ! isset( $sub_types[ $sub_type ] ) ) {
+				// Force empty result set.
+				$paged = CORE_SITEMAPS_MAX_URLS + 1;
 			}
 
 			$this->sub_type = $sub_types[ $sub_type ]->name;

--- a/inc/class-core-sitemaps-posts.php
+++ b/inc/class-core-sitemaps-posts.php
@@ -82,4 +82,20 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	public function rewrite_query() {
 		return 'index.php?sitemap=' . $this->slug . '&sub_type=$matches[1]&paged=$matches[2]';
 	}
+
+	public function get_sitemaps() {
+		$sitemaps = array();
+
+		foreach ( $this->get_object_sub_types() as $type ) {
+			$query = $this->index_query( $type->name );
+
+			$total = isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
+			for ( $i = 1; $i <= $total; $i ++ ) {
+				$slug       = implode( '-', array_filter( array( $this->slug, $type->name, (string) $i ) ) );
+				$sitemaps[] = $slug;
+			}
+		}
+
+		return $sitemaps;
+	}
 }

--- a/inc/class-core-sitemaps-posts.php
+++ b/inc/class-core-sitemaps-posts.php
@@ -36,14 +36,13 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 
 			$sub_types = $this->get_object_sub_types();
 
-			if ( ! isset( $sub_types[ $sub_type ] ) ) {
-				// Force empty result set.
+			if ( isset( $sub_types[ $sub_type ] ) ) {
+				$this->sub_type = $sub_types[ $sub_type ]->name;
+			} else {
+				// $this->sub_type remains empty and is handled by get_url_list().
+				// Force a super large page number so the result set will be empty.
 				$paged = CORE_SITEMAPS_MAX_URLS + 1;
-				// TODO does not deal with the problem.
 			}
-
-			// TODO doesn't work if the if statement doesn't match.
-			$this->sub_type = $sub_types[ $sub_type ]->name;
 
 			$url_list = $this->get_url_list( $paged );
 			$renderer = new Core_Sitemaps_Renderer();

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -26,7 +26,6 @@ class Core_Sitemaps_Provider {
 
 	/**
 	 * Sitemap route
-	 *
 	 * Regex pattern used when building the route for a sitemap.
 	 *
 	 * @var string
@@ -35,7 +34,6 @@ class Core_Sitemaps_Provider {
 
 	/**
 	 * Sitemap slug
-	 *
 	 * Used for building sitemap URLs.
 	 *
 	 * @var string
@@ -46,14 +44,10 @@ class Core_Sitemaps_Provider {
 	 * Get a URL list for a post type sitemap.
 	 *
 	 * @param int $page_num Page of results.
-	 *
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
 	public function get_url_list( $page_num ) {
-		$type = $this->sub_type;
-		if ( empty( $type ) ) {
-			$type = $this->object_type;
-		}
+		$type = $this->get_active_type();
 
 		$query = new WP_Query(
 			array(
@@ -83,7 +77,6 @@ class Core_Sitemaps_Provider {
 		 * Filter the list of URLs for a sitemap before rendering.
 		 *
 		 * @since 0.1.0
-		 *
 		 * @param array  $url_list List of URLs for a sitemap.
 		 * @param string $type     Name of the post_type.
 		 * @param int    $page_num Page of results.
@@ -98,5 +91,52 @@ class Core_Sitemaps_Provider {
 	 */
 	public function rewrite_query() {
 		return 'index.php?sitemap=' . $this->slug . '&paged=$matches[1]';
+	}
+
+	public function get_sitemaps() {
+		$sitemaps = [];
+
+		$query = $this->index_query();
+
+		$total = isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
+		for ( $i = 1; $i <= $total; $i ++ ) {
+			$slug       = implode( '-', array_filter( array( $this->slug, $this->sub_type, (string) $i ) ) );
+			$sitemaps[] = $slug;
+		}
+
+		return $sitemaps;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_active_type() {
+		$type = $this->sub_type;
+		if ( empty( $type ) ) {
+			$type = $this->object_type;
+		}
+
+		return $type;
+	}
+
+	/**
+	 * @param string $type
+	 * @return WP_Query
+	 */
+	public function index_query( $type = '' ) {
+		if ( empty( $type ) ) {
+			$type = $this->get_active_type();
+		}
+		$query = new WP_Query(
+			array(
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+				'post_type'      => $type,
+				'posts_per_page' => CORE_SITEMAPS_POSTS_PER_PAGE,
+				'paged'          => 1,
+			)
+		);
+
+		return $query;
 	}
 }

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -26,6 +26,7 @@ class Core_Sitemaps_Provider {
 
 	/**
 	 * Sitemap route
+	 *
 	 * Regex pattern used when building the route for a sitemap.
 	 *
 	 * @var string
@@ -34,6 +35,7 @@ class Core_Sitemaps_Provider {
 
 	/**
 	 * Sitemap slug
+	 *
 	 * Used for building sitemap URLs.
 	 *
 	 * @var string
@@ -77,6 +79,7 @@ class Core_Sitemaps_Provider {
 		 * Filter the list of URLs for a sitemap before rendering.
 		 *
 		 * @since 0.1.0
+		 *
 		 * @param array  $url_list List of URLs for a sitemap.
 		 * @param string $type     Name of the post_type.
 		 * @param int    $page_num Page of results.
@@ -100,6 +103,7 @@ class Core_Sitemaps_Provider {
 	 */
 	public function get_queried_type() {
 		$type = $this->sub_type;
+
 		if ( empty( $type ) ) {
 			$type = $this->object_type;
 		}
@@ -110,21 +114,24 @@ class Core_Sitemaps_Provider {
 	/**
 	 * Query for determining the number of pages.
 	 *
-	 * @param string $type Object Type.
+	 * @param string $type Optional. Object type. Default is null.
 	 * @return int Total number of pages.
 	 */
 	public function max_num_pages( $type = null ) {
 		if ( empty( $type ) ) {
 			$type = $this->get_queried_type();
 		}
+
 		$query = new WP_Query(
 			array(
-				'fields'         => 'ids',
-				'orderby'        => 'ID',
-				'order'          => 'ASC',
-				'post_type'      => $type,
-				'posts_per_page' => CORE_SITEMAPS_POSTS_PER_PAGE,
-				'paged'          => 1,
+				'fields'                 => 'ids',
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+				'post_type'              => $type,
+				'posts_per_page'         => CORE_SITEMAPS_POSTS_PER_PAGE,
+				'paged'                  => 1,
+				'update_post_term_cache' => false,
+				'update_post_meta_cache' => false,
 			)
 		);
 
@@ -151,13 +158,14 @@ class Core_Sitemaps_Provider {
 	}
 
 	/**
-	 * Stub a fake object type, to get the name of.
-	 * This attempts compatibility with object types such as post, category, user.
-	 * This must support providers for multiple sub-types, so a list is returned.
+	 * Return the list of supported object sub-types exposed by the provider.
+	 *
+	 * By default this is the sub_type as specified in the class property.
 	 *
 	 * @return array List of object types.
 	 */
 	public function get_object_sub_types() {
+		// FIXME: fix this hack.
 		$c       = new stdClass();
 		$c->name = $this->sub_type;
 

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -119,6 +119,7 @@ class Core_Sitemaps_Provider {
 		}
 		$query = new WP_Query(
 			array(
+				'fields'         => 'ids',
 				'orderby'        => 'ID',
 				'order'          => 'ASC',
 				'post_type'      => $type,

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -147,10 +147,6 @@ class Core_Sitemaps_Provider {
 		$sitemaps = array();
 
 		$sitemap_types = $this->get_object_sub_types();
-		if ( empty( $sitemap_types ) ) {
-			// By default, providers without sub-types are processed based on their object_type.
-			$sitemap_types = array( $this->object_type );
-		}
 
 		foreach ( $sitemap_types as $type ) {
 			// Handle object names as strings.
@@ -176,13 +172,13 @@ class Core_Sitemaps_Provider {
 	 *
 	 * By default this is the sub_type as specified in the class property.
 	 *
-	 * @return array List of object types, or empty if there are no subtypes.
+	 * @return array List: containing object types or false if there are no subtypes.
 	 */
 	public function get_object_sub_types() {
 		if ( ! empty( $this->sub_type ) ) {
 			return array( $this->sub_type );
 		}
 
-		return array();
+		return array( false );
 	}
 }

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -179,6 +179,13 @@ class Core_Sitemaps_Provider {
 			return array( $this->sub_type );
 		}
 
+		/**
+		 * To prevent complexity in code calling this function, such as `get_sitemaps()` in this class,
+		 * an iterable type is returned. The value false was chosen as it passes empty() checks and
+		 * as semantically this provider does not provide sub-types.
+		 *
+		 * @link https://github.com/GoogleChromeLabs/wp-sitemaps/pull/72#discussion_r347496750
+		 */
 		return array( false );
 	}
 }

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -146,10 +146,24 @@ class Core_Sitemaps_Provider {
 	public function get_sitemaps() {
 		$sitemaps = array();
 
-		foreach ( $this->get_object_sub_types() as $type ) {
-			$total = $this->max_num_pages( $type->name );
+		$sitemap_types = $this->get_object_sub_types();
+		if ( empty( $sitemap_types ) ) {
+			// By default, providers without sub-types are processed based on their object_type.
+			$sitemap_types = array( $this->object_type );
+		}
+
+		foreach ( $sitemap_types as $type ) {
+			// Handle object names as strings.
+			$name = $type;
+
+			// Handle lists of post-objects.
+			if ( isset( $type->name ) ) {
+				$name = $type->name;
+			}
+
+			$total = $this->max_num_pages( $name );
 			for ( $i = 1; $i <= $total; $i ++ ) {
-				$slug       = implode( '-', array_filter( array( $this->slug, $type->name, (string) $i ) ) );
+				$slug       = implode( '-', array_filter( array( $this->slug, $name, (string) $i ) ) );
 				$sitemaps[] = $slug;
 			}
 		}
@@ -162,13 +176,13 @@ class Core_Sitemaps_Provider {
 	 *
 	 * By default this is the sub_type as specified in the class property.
 	 *
-	 * @return array List of object types.
+	 * @return array List of object types, or empty if there are no subtypes.
 	 */
 	public function get_object_sub_types() {
-		// FIXME: fix this hack.
-		$c       = new stdClass();
-		$c->name = $this->sub_type;
+		if ( ! empty( $this->sub_type ) ) {
+			return array( $this->sub_type );
+		}
 
-		return array( $c );
+		return array();
 	}
 }

--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -13,7 +13,6 @@ class Core_Sitemaps_Renderer {
 	 * Get the URL for a specific sitemap.
 	 *
 	 * @param string $name The name of the sitemap to get a URL for.
-	 *
 	 * @return string the sitemap index url.
 	 */
 	public function get_sitemap_url( $name ) {
@@ -41,9 +40,9 @@ class Core_Sitemaps_Renderer {
 		header( 'Content-type: application/xml; charset=UTF-8' );
 		$sitemap_index = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8" ?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>' );
 
-		foreach ( $sitemaps as $link ) {
+		foreach ( $sitemaps as $slug ) {
 			$sitemap = $sitemap_index->addChild( 'sitemap' );
-			$sitemap->addChild( 'loc', esc_url( $this->get_sitemap_url( $link->slug ) ) );
+			$sitemap->addChild( 'loc', esc_url( $this->get_sitemap_url( $slug ) ) );
 			$sitemap->addChild( 'lastmod', '2004-10-01T18:23:17+00:00' );
 		}
 		// All output is escaped within the addChild method calls.

--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -56,8 +56,15 @@ class Core_Sitemaps_Renderer {
 	 * @param array $url_list A list of URLs for a sitemap.
 	 */
 	public function render_sitemap( $url_list ) {
+		global $wp_query;
+
 		header( 'Content-type: application/xml; charset=UTF-8' );
 		$urlset = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8" ?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>' );
+
+		if ( empty( $url_list ) ) {
+			$wp_query->set_404();
+			status_header( 404 );
+		}
 
 		foreach ( $url_list as $url_item ) {
 			$url = $urlset->addChild( 'url' );

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -142,29 +142,15 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		return 'index.php?sitemap=' . $this->slug . '&sub_type=$matches[1]&paged=$matches[2]';
 	}
 
-	public function get_sitemaps() {
-		$sitemaps = array();
-
-		foreach ( $this->get_object_sub_types() as $type ) {
-			$query = $this->index_query( $type->name );
-
-			$total = isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
-			for ( $i = 1; $i <= $total; $i ++ ) {
-				$slug       = implode( '-', array_filter( array( $this->slug, $type->name, (string) $i ) ) );
-				$sitemaps[] = $slug;
-			}
-		}
-
-		return $sitemaps;
-	}
-
 	/**
-	 * @param string $type
-	 * @return WP_Term_Query
+	 * Sitemap Index query for determining the number of pages.
+	 *
+	 * @param string $type Taxonomy name.
+	 * @return int Total number of pages.
 	 */
-	public function index_query( $type = '' ) {
+	public function max_num_pages( $type = '' ) {
 		if ( empty( $type ) ) {
-			$type = $this->get_active_type();
+			$type = $this->get_queried_type();
 		}
 		$args = array(
 			'fields'     => 'ids',
@@ -177,6 +163,6 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 
 		$query = new WP_Term_Query( $args );
 
-		return $query;
+		return isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
 	}
 }

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -64,7 +64,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		$type = $this->sub_type;
 
 		if ( empty( $type ) ) {
-			return;
+			return array();
 		}
 
 		$url_list = array();

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -37,12 +37,10 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		}
 
 		if ( $this->slug === $sitemap ) {
-			if ( ! isset( $sub_types[ $sub_type ] ) ) {
-				// Invalid sub type.
+			if ( ! isset( $sub_types[ $sub_type ] ) || $paged > $this->max_num_pages( $sub_type ) ) {
+				// Invalid sub type or out of range pagination.
 				$wp_query->set_404();
 				status_header( 404 );
-
-				return;
 			}
 
 			$url_list = $this->get_url_list( $paged );

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -106,6 +106,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		 * Filter the list of URLs for a sitemap before rendering.
 		 *
 		 * @since 0.1.0
+		 *
 		 * @param array  $url_list List of URLs for a sitemap.
 		 * @param string $type     Name of the taxonomy_type.
 		 * @param int    $page_num Page of results.
@@ -123,6 +124,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		 * Filter the list of taxonomy object sub types available within the sitemap.
 		 *
 		 * @since 0.1.0
+		 *
 		 * @param array $taxonomy_types List of registered object sub types.
 		 */
 		return apply_filters( 'core_sitemaps_taxonomies', $taxonomy_types );
@@ -147,6 +149,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		if ( empty( $type ) ) {
 			$type = $this->get_queried_type();
 		}
+
 		$args = array(
 			'fields'     => 'ids',
 			'taxonomy'   => $type,

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -112,7 +112,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		 *
 		 * @since 0.1.0
 		 * @param array  $url_list List of URLs for a sitemap.
-		 * @param string $type     .       Name of the taxonomy_type.
+		 * @param string $type     Name of the taxonomy_type.
 		 * @param int    $page_num Page of results.
 		 */
 		return apply_filters( 'core_sitemaps_taxonomies_url_list', $url_list, $type, $page_num );

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -57,7 +57,6 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 * Get a URL list for a taxonomy sitemap.
 	 *
 	 * @param int $page_num Page of results.
-	 *
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
 	public function get_url_list( $page_num ) {
@@ -112,10 +111,9 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		 * Filter the list of URLs for a sitemap before rendering.
 		 *
 		 * @since 0.1.0
-		 *
-		 * @param array  $url_list    List of URLs for a sitemap.
-		 * @param string $type.       Name of the taxonomy_type.
-		 * @param int    $page_num    Page of results.
+		 * @param array  $url_list List of URLs for a sitemap.
+		 * @param string $type     .       Name of the taxonomy_type.
+		 * @param int    $page_num Page of results.
 		 */
 		return apply_filters( 'core_sitemaps_taxonomies_url_list', $url_list, $type, $page_num );
 	}
@@ -129,9 +127,8 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		/**
 		 * Filter the list of taxonomy object sub types available within the sitemap.
 		 *
-		 * @param array $taxonomy_types List of registered object sub types.
-		 *
 		 * @since 0.1.0
+		 * @param array $taxonomy_types List of registered object sub types.
 		 */
 		return apply_filters( 'core_sitemaps_taxonomies', $taxonomy_types );
 	}
@@ -145,4 +142,41 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		return 'index.php?sitemap=' . $this->slug . '&sub_type=$matches[1]&paged=$matches[2]';
 	}
 
+	public function get_sitemaps() {
+		$sitemaps = array();
+
+		foreach ( $this->get_object_sub_types() as $type ) {
+			$query = $this->index_query( $type->name );
+
+			$total = isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
+			for ( $i = 1; $i <= $total; $i ++ ) {
+				$slug       = implode( '-', array_filter( array( $this->slug, $type->name, (string) $i ) ) );
+				$sitemaps[] = $slug;
+			}
+		}
+
+		return $sitemaps;
+	}
+
+	/**
+	 * @param string $type
+	 * @return WP_Query
+	 */
+	public function index_query( $type = '' ) {
+		if ( empty( $type ) ) {
+			$type = $this->get_active_type();
+		}
+		$args = array(
+			'fields'     => 'ids',
+			'taxonomy'   => $type,
+			'orderby'    => 'term_order',
+			'number'     => CORE_SITEMAPS_POSTS_PER_PAGE,
+			'paged'      => 1,
+			'hide_empty' => true,
+		);
+
+		$query = new WP_Term_Query( $args );
+
+		return $query;
+	}
 }

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -23,24 +23,21 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 * Produce XML to output.
 	 */
 	public function render_sitemap() {
-		global $wp_query;
-
 		$sitemap  = get_query_var( 'sitemap' );
 		$sub_type = get_query_var( 'sub_type' );
 		$paged    = get_query_var( 'paged' );
 
-		$sub_types = $this->get_object_sub_types();
-
-		$this->sub_type = $sub_types[ $sub_type ]->name;
-		if ( empty( $paged ) ) {
-			$paged = 1;
-		}
-
 		if ( $this->slug === $sitemap ) {
-			if ( ! isset( $sub_types[ $sub_type ] ) || $paged > $this->max_num_pages( $sub_type ) ) {
-				// Invalid sub type or out of range pagination.
-				$wp_query->set_404();
-				status_header( 404 );
+			$sub_types = $this->get_object_sub_types();
+
+			$this->sub_type = $sub_types[ $sub_type ]->name;
+			if ( empty( $paged ) ) {
+				$paged = 1;
+			}
+
+			if ( ! isset( $sub_types[ $sub_type ] ) ) {
+				// Force empty result set.
+				$paged = CORE_SITEMAPS_MAX_URLS + 1;
 			}
 
 			$url_list = $this->get_url_list( $paged );

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -160,7 +160,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 
 	/**
 	 * @param string $type
-	 * @return WP_Query
+	 * @return WP_Term_Query
 	 */
 	public function index_query( $type = '' ) {
 		if ( empty( $type ) ) {

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -84,11 +84,10 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 		$sitemap = get_query_var( 'sitemap' );
 		$paged   = get_query_var( 'paged' );
 
-		if ( empty( $paged ) ) {
-			$paged = 1;
-		}
-
 		if ( 'users' === $sitemap ) {
+			if ( empty( $paged ) ) {
+				$paged = 1;
+			}
 			$url_list = $this->get_url_list( $paged );
 			$renderer = new Core_Sitemaps_Renderer();
 			$renderer->render_sitemap( $url_list );

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -103,7 +103,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * @param integer $page_num Optional. Default is 1. Page of query results to return.
 	 * @return WP_User_Query
 	 */
-	public function get_public_post_authors_query( $page_num = null ) {
+	public function get_public_post_authors_query( $page_num = 1 ) {
 		$public_post_types = get_post_types(
 			array(
 				'public' => true,
@@ -112,10 +112,6 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 
 		// We're not supporting sitemaps for author pages for attachments.
 		unset( $public_post_types['attachment'] );
-
-		if ( null === $page_num ) {
-			$page_num = 1;
-		}
 
 		$query = new WP_User_Query(
 			array(

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -96,7 +96,13 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 		}
 	}
 
-	public function index_query() {
+	/**
+	 * Return max number of pages available for the object type.
+	 *
+	 * @param string $type Name of the object type.
+	 * @return int Total page count.
+	 */
+	public function max_num_pages( $type = null ) {
 		$public_post_types = get_post_types(
 			array(
 				'public' => true,
@@ -114,6 +120,6 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 			)
 		);
 
-		return $query;
+		return isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
 	}
 }

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * The Core_Sitemaps_Users sitemap provider.
+ *
  * This class extends Core_Sitemaps_Provider to support sitemaps for user pages in WordPress.
  *
  * @package Core_Sitemaps
@@ -68,6 +69,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 		 * Filter the list of URLs for a sitemap before rendering.
 		 *
 		 * @since 0.1.0
+		 *
 		 * @param string $object_type Name of the post_type.
 		 * @param int    $page_num    Page of results.
 		 * @param array  $url_list    List of URLs for a sitemap.
@@ -102,6 +104,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * @return int Total page count.
 	 */
 	public function max_num_pages( $type = null ) {
+		// FIXME Can we abstract the functionality here that gets a list of authors with public posts since it's also being used in get_url_list()?
 		$public_post_types = get_post_types(
 			array(
 				'public' => true,

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * The Core_Sitemaps_Users sitemap provider.
- *
  * This class extends Core_Sitemaps_Provider to support sitemaps for user pages in WordPress.
  *
  * @package Core_Sitemaps
@@ -24,7 +23,6 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * Get a URL list for a user sitemap.
 	 *
 	 * @param int $page_num Page of results.
-	 *
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
 	public function get_url_list( $page_num ) {
@@ -70,10 +68,8 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 		 * Filter the list of URLs for a sitemap before rendering.
 		 *
 		 * @since 0.1.0
-		 *
 		 * @param string $object_type Name of the post_type.
 		 * @param int    $page_num    Page of results.
-		 *
 		 * @param array  $url_list    List of URLs for a sitemap.
 		 */
 		return apply_filters( 'core_sitemaps_users_url_list', $url_list, $object_type, $page_num );
@@ -98,5 +94,26 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 			$renderer->render_sitemap( $url_list );
 			exit;
 		}
+	}
+
+	public function index_query() {
+		$public_post_types = get_post_types(
+			array(
+				'public' => true,
+			)
+		);
+
+		// We're not supporting sitemaps for author pages for attachments.
+		unset( $public_post_types['attachment'] );
+
+		$query = new WP_User_Query(
+			array(
+				'has_published_posts' => array_keys( $public_post_types ),
+				'number'              => CORE_SITEMAPS_POSTS_PER_PAGE,
+				'paged'               => 1,
+			)
+		);
+
+		return $query;
 	}
 }

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -114,6 +114,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 
 		$query = new WP_User_Query(
 			array(
+				'fields'              => 'ids',
 				'has_published_posts' => array_keys( $public_post_types ),
 				'number'              => CORE_SITEMAPS_POSTS_PER_PAGE,
 				'paged'               => 1,

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Class file for the Core_Sitemaps class.
+ *
  * This is the main class integrating all other classes.
  *
  * @package Core_Sitemaps
@@ -59,6 +60,7 @@ class Core_Sitemaps {
 		 * Filters the list of registered sitemap providers.
 		 *
 		 * @since 0.1.0
+		 *
 		 * @param array $providers Array of Core_Sitemap_Provider objects.
 		 */
 		$providers = apply_filters(

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -75,7 +75,6 @@ class Core_Sitemaps {
 			$sitemaps = $provider->get_sitemaps();
 			foreach ( $sitemaps as $sitemap ) {
 				$this->registry->add_sitemap( $sitemap, $provider );
-
 			}
 		}
 	}

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -59,7 +59,6 @@ class Core_Sitemaps {
 		 * Filters the list of registered sitemap providers.
 		 *
 		 * @since 0.1.0
-		 *
 		 * @param array $providers Array of Core_Sitemap_Provider objects.
 		 */
 		$providers = apply_filters(
@@ -73,7 +72,11 @@ class Core_Sitemaps {
 
 		// Register each supported provider.
 		foreach ( $providers as $provider ) {
-			$this->registry->add_sitemap( $provider->slug, $provider );
+			$sitemaps = $provider->get_sitemaps();
+			foreach ( $sitemaps as $sitemap ) {
+				$this->registry->add_sitemap( $sitemap, $provider );
+
+			}
 		}
 	}
 


### PR DESCRIPTION
### Issue Number
2nd iteration following #68, adding to #48.

Fixes #71.

### Description
Supports the registration of sitemap names for providers with 0 or more object sub types.
This includes iterating pages.

Each provider provides the sitemaps that should be available in the index which are object-type, sub-type and page specific.

Third party providers add support by adding `max_num_pages($type=null)` method that returns the total page count for the provided object (sub)type, as this depends on how the type is queried (type is optional for providers without sub types).

**Known issues:**
Some of the page count queries can perhaps be simplified using SELECT COUNT(ID) perhaps. and ~there might not be a need to build up an stub object type if can can just pass the name and simplify it~ (update: simplified), but not looked into those things yet. Because the new methods return a page count, they should be easily switchable when the bucket cpt is ready.

### Screenshots (before and after if applicable)
![image](https://user-images.githubusercontent.com/594871/68962071-a9fe6b00-07cb-11ea-902d-cbabd942707c.png)


### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
SM-Tests
http://sitemaps.local/sitemap.xml
http://sitemaps.local/sitemap-posts-post.xml
http://sitemaps.local/sitemap-posts-post-1.xml
http://sitemaps.local/sitemap-users.xml
http://sitemaps.local/sitemap-taxonomies-post_format-1.xml
http://sitemaps.local/sitemap-users-1.xml
http://sitemaps.local/sitemap-taxonomies-post_tag-1.xml

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [x] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
