### PR TITLE
Fix sitemap pagination for taxonomy sitemap pages

### DIFF
--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -68,16 +68,16 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		$offset = ( $page_num - 1 ) * CORE_SITEMAPS_POSTS_PER_PAGE;
 
 		$args = array(
-			'taxonomy'     => $type,
-			'orderby'      => 'term_order',
-			'number'       => CORE_SITEMAPS_POSTS_PER_PAGE,
-			'offset'       => $offset,
-			'hide_empty'   => true,
+			'taxonomy'               => $type,
+			'orderby'                => 'term_order',
+			'number'                 => CORE_SITEMAPS_POSTS_PER_PAGE,
+			'offset'                 => $offset,
+			'hide_empty'             => true,
 			/*
 			 * Limits aren't included in queries when hierarchical is set to true (by default).
 			 * See: https: //github.com/WordPress/WordPress/blob/5.3/wp-includes/class-wp-term-query.php#L558-L567
 			 */
-			'hierarchical' => false,
+			'hierarchical'           => false,
 			'update_term_meta_cache' => false
 		);
 

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -75,7 +75,8 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 			'hide_empty'             => true,
 			/*
 			 * Limits aren't included in queries when hierarchical is set to true (by default).
-			 * See: https: //github.com/WordPress/WordPress/blob/5.3/wp-includes/class-wp-term-query.php#L558-L567
+			 *
+			 * @link: https://github.com/WordPress/WordPress/blob/5.3/wp-includes/class-wp-term-query.php#L558-L567
 			 */
 			'hierarchical'           => false,
 			'update_term_meta_cache' => false

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -68,6 +68,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		$offset = ( $page_num - 1 ) * CORE_SITEMAPS_POSTS_PER_PAGE;
 
 		$args = array(
+			'fields'                 => 'ids',
 			'taxonomy'               => $type,
 			'orderby'                => 'term_order',
 			'number'                 => CORE_SITEMAPS_POSTS_PER_PAGE,

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -74,13 +74,14 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 			'number'                 => CORE_SITEMAPS_POSTS_PER_PAGE,
 			'offset'                 => $offset,
 			'hide_empty'             => true,
+
 			/*
 			 * Limits aren't included in queries when hierarchical is set to true (by default).
 			 *
 			 * @link: https://github.com/WordPress/WordPress/blob/5.3/wp-includes/class-wp-term-query.php#L558-L567
 			 */
 			'hierarchical'           => false,
-			'update_term_meta_cache' => false
+			'update_term_meta_cache' => false,
 		);
 
 		$taxonomy_terms = new WP_Term_Query( $args );


### PR DESCRIPTION
### Issue Number
This is blocked by #72. All changes are in 0ddcb36.

### Description
Previously, the paged value was being discarded when passed to the `WP_Term_Query` when getting URLs for a taxonomy sitemap page. This fixes the arguments passed to the `WP_Term_Query` so the queries return the expected values for each page.

This would be easier to test once #74 is implemented.

### Type of change
Please select the relevant options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
- Manually change the URL of a taxonomy sitemap page to a page number that is higher than the available terms and see that the first page of results are still returned.

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
