### PR TITLE
Fix pagination for taxonomy and users in the sitemap index

### DIFF
--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -163,17 +163,8 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 			$type = $this->get_queried_type();
 		}
 
-		$args = array(
-			'fields'     => 'ids',
-			'taxonomy'   => $type,
-			'orderby'    => 'term_order',
-			'number'     => core_sitemaps_get_max_urls( $this->slug ),
-			'paged'      => 1,
-			'hide_empty' => true,
-		);
+		$term_count = wp_count_terms( $type, array( 'hide_empty' => true ) );
 
-		$query = new WP_Term_Query( $args );
-
-		return isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
+		return ceil( $term_count / core_sitemaps_get_max_urls( $this->slug ) );
 	}
 }

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -85,14 +85,16 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	/**
 	 * Return max number of pages available for the object type.
 	 *
-	 * @see \Core_Sitemaps_Provider::max_num_pages
+	 * @see Core_Sitemaps_Provider::max_num_pages
 	 * @param string $type Optional. Name of the object type. Default is null.
 	 * @return int Total page count.
 	 */
 	public function max_num_pages( $type = null ) {
 		$query = $this->get_public_post_authors_query();
 
-		return isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
+		$total_users = $query->get_total();
+
+		return ceil( $total_users / core_sitemaps_get_max_urls( $this->slug ) );
 	}
 
 	/**


### PR DESCRIPTION
### Issue Number
Fixes #78. Blocked by #82.

### Description
This fixes the `max_num_pages()` implementations for the taxonomies and users sitemap providers which is used to determine how many sitemap pages should be available.

### Type of change
Please select the relevant options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Following #74, filter the value for max URLs per sitemap so that multiple pages should be available for a taxonomy term or for users and see that before this change is applied, only one sitemap pages shows up in the sitemap index. After applying this change, you should see multiple pages for terms and users if enough URLs can be generated to force multiple pages.

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have added test instructions that prove my fix is effective or that my feature works.
