### PR TITLE
Fix core_sitemaps_users_url_list filter params and docs.

### DIFF
--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -55,11 +55,10 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 		 *
 		 * @since 0.1.0
 		 *
-		 * @param string $object_type Name of the post_type.
-		 * @param int    $page_num    Page of results.
 		 * @param array  $url_list    List of URLs for a sitemap.
+		 * @param int    $page_num    Page of results.
 		 */
-		return apply_filters( 'core_sitemaps_users_url_list', $url_list, $object_type, $page_num );
+		return apply_filters( 'core_sitemaps_users_url_list', $url_list, $page_num );
 	}
 
 	/**


### PR DESCRIPTION
Related to #23.

### Description
This removes the redundant `$object_type` parameter, which doesn't really serve any function since there are no sub-types for users and corrects the inline filter docs parameter order.

### Screenshots (before and after if applicable)
If your PR includes visual changes include before and after screenshots showing the change.

### Type of change
Please select the relevant options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
