### PR TITLE
Add lastmod values to the sitemap index

### DIFF
--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -75,7 +75,7 @@ class Core_Sitemaps_Index {
 			$sitemaps = array();
 
 			// Build up the list of sitemap pages.
-			foreach( $providers as $provider ) {
+			foreach ( $providers as $provider ) {
 				$sitemaps = array_merge( $sitemaps, $provider->get_sitemap_entries() );
 			}
 

--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -70,8 +70,16 @@ class Core_Sitemaps_Index {
 		$sitemap_index = get_query_var( 'sitemap' );
 
 		if ( 'index' === $sitemap_index ) {
-			$sitemaps = core_sitemaps_get_sitemaps();
-			$this->renderer->render_index( array_keys( $sitemaps ) );
+			$providers = core_sitemaps_get_sitemaps();
+
+			$sitemaps = array();
+
+			// Build up the list of sitemap pages.
+			foreach( $providers as $provider ) {
+				$sitemaps = array_merge( $sitemaps, $provider->get_sitemap_entries() );
+			}
+
+			$this->renderer->render_index( $sitemaps );
 			exit;
 		}
 	}

--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -74,7 +74,6 @@ class Core_Sitemaps_Index {
 
 			$sitemaps = array();
 
-			// Build up the list of sitemap pages.
 			foreach ( $providers as $provider ) {
 				$sitemaps = array_merge( $sitemaps, $provider->get_sitemap_entries() );
 			}

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -279,7 +279,12 @@ class Core_Sitemaps_Provider {
 
 		// If blank, schedule a job.
 		if ( empty( $lastmod ) && ! wp_doing_cron() ) {
-			wp_schedule_single_event( time() + 500, 'core_sitemaps_calculate_lastmod', array( $this->slug, $name, $page ) );
+			$event_args = array( $this->slug, $name, $page );
+
+			// Don't schedule a duplicate job.
+			if ( ! wp_next_scheduled( 'core_sitemaps_calculate_lastmod', $event_args ) ) {
+				wp_schedule_single_event( time() + 500, 'core_sitemaps_calculate_lastmod', $event_args );
+			}
 		}
 
 		return $lastmod;

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -316,20 +316,16 @@ class Core_Sitemaps_Provider {
 			return;
 		}
 
-		$list = $this->get_url_list( $page, $subtype );
+		// Get the list of URLs from this page and sort it by lastmod date.
+		$url_list    = $this->get_url_list( $page, $subtype );
+		$sorted_list = wp_list_sort( $url_list, 'lastmod', 'DESC' );
 
-		$times = wp_list_pluck( $list, 'lastmod' );
-
-		usort(
-			$times,
-			function( $a, $b ) {
-				return strtotime( $b ) - strtotime( $a );
-			}
-		);
+		// Use the most recent lastmod value as the lastmod value for the sitemap page.
+		$lastmod = reset( $sorted_list )['lastmod'];
 
 		$suffix = implode( '_', array_filter( array( $type, $subtype, (string) $page ) ) );
 
-		update_option( "core_sitemaps_lastmod_$suffix", $times[0] );
+		update_option( "core_sitemaps_lastmod_$suffix", $lastmod );
 	}
 
 	/**

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -175,11 +175,13 @@ class Core_Sitemaps_Provider {
 	}
 
 	/**
-	 * List of sitemaps exposed by this provider.
+	 * List of sitemap pages exposed by this provider.
+	 *
+	 * The returned data is used to populate the sitemap entries of the index.
 	 *
 	 * @return array List of sitemaps.
 	 */
-	public function get_sitemaps() {
+	public function get_sitemap_entries() {
 		$sitemaps = array();
 
 		$sitemap_types = $this->get_object_sub_types();
@@ -194,13 +196,61 @@ class Core_Sitemaps_Provider {
 			}
 
 			$total = $this->max_num_pages( $name );
-			for ( $i = 1; $i <= $total; $i ++ ) {
-				$slug       = implode( '-', array_filter( array( $this->slug, $name, (string) $i ) ) );
-				$sitemaps[] = $slug;
+
+			for ( $page = 1; $page <= $total; $page ++ ) {
+				$loc        = $this->get_sitemap_url( $name, $page );
+				$lastmod    = $this->get_sitemap_lastmod( $name, $page );
+				$sitemaps[] = array(
+					'loc'     => $loc,
+					'lastmod' => $lastmod,
+				);
 			}
 		}
 
 		return $sitemaps;
+	}
+
+	/**
+	 * Get the URL of a sitemap entry.
+	 *
+	 * @param string $name The name of the sitemap.
+	 * @param int    $page The page of the sitemap.
+	 * @return string The composed URL for a sitemap entry.
+	 */
+	public function get_sitemap_url( $name, $page ) {
+		global $wp_rewrite;
+
+		$basename = sprintf(
+			'/sitemap-%1$s.xml',
+			// Accounts for cases where name is not included, ex: sitemaps-users-1.xml.
+			implode( '-', array_filter( array( $this->slug, $name, (string) $page ) ) )
+		);
+
+		$url = home_url( $basename );
+
+		if ( ! $wp_rewrite->using_permalinks() ) {
+			$url = add_query_arg(
+				array(
+					'sitemap'  => $this->slug,
+					'sub_type' => $name,
+					'paged'    => $page,
+				),
+				home_url( '/' )
+			);
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Get the last modified date for a sitemap page.
+	 *
+	 * @param string $name The name of the sitemap.
+	 * @param int    $page The page of the sitemap being returned.
+	 * @return string The GMT date of the most recently changed date.
+	 */
+	public function get_sitemap_lastmod( $name, $page ) {
+		return '0000-00-00 00:00Z GMT';
 	}
 
 	/**

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -283,7 +283,7 @@ class Core_Sitemaps_Provider {
 
 			// Don't schedule a duplicate job.
 			if ( ! wp_next_scheduled( 'core_sitemaps_calculate_lastmod', $event_args ) ) {
-				wp_schedule_single_event( time() + 500, 'core_sitemaps_calculate_lastmod', $event_args );
+				wp_schedule_single_event( time(), 'core_sitemaps_calculate_lastmod', $event_args );
 			}
 		}
 
@@ -340,7 +340,7 @@ class Core_Sitemaps_Provider {
 			$total = $this->max_num_pages( $name );
 
 			for ( $page = 1; $page <= $total; $page ++ ) {
-				wp_schedule_single_event( time() + 500, 'core_sitemaps_calculate_lastmod', array( $this->slug, $name, $page ) );
+				wp_schedule_single_event( time(), 'core_sitemaps_calculate_lastmod', array( $this->slug, $name, $page ) );
 			}
 		}
 	}

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -90,10 +90,11 @@ class Core_Sitemaps_Provider {
 	/**
 	 * Get a URL list for a post type sitemap.
 	 *
-	 * @param int $page_num Page of results.
+	 * @param int    $page_num Page of results.
+	 * @param string $type     Optional. Post type name. Default ''.
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num, $type = null ) {
+	public function get_url_list( $page_num, $type = '' ) {
 		if ( ! $type ) {
 			$type = $this->get_queried_type();
 		}
@@ -295,9 +296,12 @@ class Core_Sitemaps_Provider {
 
 		$times = wp_list_pluck( $list, 'lastmod' );
 
-		usort( $times, function( $a, $b ) {
-			return strtotime( $b ) - strtotime( $a );
-		} );
+		usort(
+			$times,
+			function( $a, $b ) {
+				return strtotime( $b ) - strtotime( $a );
+			}
+		);
 
 		$suffix = implode( '_', array_filter( array( $type, $subtype, (string) $page ) ) );
 

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -55,7 +55,19 @@ class Core_Sitemaps_Provider {
 		add_action( 'core_sitemaps_update_lastmod_' . $this->slug, array( $this, 'update_lastmod_values' ) );
 
 		if ( ! wp_next_scheduled( 'core_sitemaps_update_lastmod_' . $this->slug ) && ! wp_installing() ) {
-			wp_schedule_event( time(), 'twicedaily', 'core_sitemaps_update_lastmod_' . $this->slug );
+
+			/**
+			 * Filter the recurrence value for updating sitemap lastmod values.
+			 *
+			 * @since 0.1.0
+			 *
+			 * @param string $recurrence How often the event should subsequently recur. Default 'twicedaily'.
+			 *                           See wp_get_schedules() for accepted values.
+			 * @param string $type       The object type being handled by this event, e.g. posts, taxonomies, users.
+			 */
+			$lastmod_recurrence = apply_filters( 'core_sitemaps_lastmod_recurrence', 'twicedaily', $this->slug );
+
+			wp_schedule_event( time(), $lastmod_recurrence, 'core_sitemaps_update_lastmod_' . $this->slug );
 		}
 	}
 

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -322,8 +322,6 @@ class Core_Sitemaps_Provider {
 
 	/**
 	 * Schedules asynchronous tasks to update lastmod entries for all sitemap pages.
-	 *
-	 * @return void
 	 */
 	public function update_lastmod_values() {
 		$sitemap_types = $this->get_object_sub_types();

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -275,7 +275,7 @@ class Core_Sitemaps_Provider {
 		$type = implode( '_', array_filter( array( $this->slug, $name, (string) $page ) ) );
 
 		// Check for an option.
-		$lastmod = get_option( "core_sitemaps_lasmod_$type", '' );
+		$lastmod = get_option( "core_sitemaps_lastmod_$type", '' );
 
 		// If blank, schedule a job.
 		if ( empty( $lastmod ) && ! wp_doing_cron() ) {
@@ -317,7 +317,7 @@ class Core_Sitemaps_Provider {
 
 		$suffix = implode( '_', array_filter( array( $type, $subtype, (string) $page ) ) );
 
-		update_option( "core_sitemaps_lasmod_$suffix", $times[0] );
+		update_option( "core_sitemaps_lastmod_$suffix", $times[0] );
 	}
 
 	/**

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -300,7 +300,6 @@ class Core_Sitemaps_Provider {
 	 * @param int    $page    The page number.
 	 */
 	public function calculate_sitemap_lastmod( $type, $subtype, $page ) {
-		// @todo: clean up the verbiage around type/subtype/slug/object/etc.
 		if ( $type !== $this->slug ) {
 			return;
 		}

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -244,7 +244,6 @@ class Core_Sitemaps_Provider {
 		$sitemap_types = $this->get_sitemap_type_data();
 
 		foreach ( $sitemap_types as $type ) {
-
 			for ( $page = 1; $page <= $type['pages']; $page ++ ) {
 				$loc        = $this->get_sitemap_url( $type['name'], $page );
 				$lastmod    = $this->get_sitemap_lastmod( $type['name'], $page );

--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -34,28 +34,6 @@ class Core_Sitemaps_Renderer {
 	}
 
 	/**
-	 * Get the URL for a specific sitemap.
-	 *
-	 * @param string $name The name of the sitemap to get a URL for.
-	 * @return string the sitemap index url.
-	 */
-	public function get_sitemap_url( $name ) {
-		global $wp_rewrite;
-
-		$home_url_append = '';
-		if ( 'index' !== $name ) {
-			$home_url_append = '-' . $name;
-		}
-		$url = home_url( sprintf( '/sitemap%1$s.xml', $home_url_append ) );
-
-		if ( ! $wp_rewrite->using_permalinks() ) {
-			$url = add_query_arg( 'sitemap', $name, home_url( '/' ) );
-		}
-
-		return $url;
-	}
-
-	/**
 	 * Get the URL for the sitemap stylesheet.
 	 *
 	 * @return string the sitemap stylesheet url.
@@ -90,16 +68,16 @@ class Core_Sitemaps_Renderer {
 	/**
 	 * Render a sitemap index.
 	 *
-	 * @param array $sitemaps List of sitemaps, see \Core_Sitemaps_Registry::$sitemaps.
+	 * @param array $sitemaps List of sitemap entries including loc and lastmod data.
 	 */
 	public function render_index( $sitemaps ) {
 		header( 'Content-type: application/xml; charset=UTF-8' );
 		$sitemap_index = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8" ?>' . $this->stylesheet_index . '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>' );
 
-		foreach ( $sitemaps as $slug ) {
+		foreach ( $sitemaps as $entry ) {
 			$sitemap = $sitemap_index->addChild( 'sitemap' );
-			$sitemap->addChild( 'loc', esc_url( $this->get_sitemap_url( $slug ) ) );
-			$sitemap->addChild( 'lastmod', '2004-10-01T18:23:17+00:00' );
+			$sitemap->addChild( 'loc', esc_url( $entry['loc'] ) );
+			$sitemap->addChild( 'lastmod', esc_html( $entry['lastmod'] ) );
 		}
 		// All output is escaped within the addChild method calls.
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -25,9 +25,11 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 * @param int $page_num Page of results.
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num ) {
+	public function get_url_list( $page_num, $type = null ) {
 		// Find the query_var for sub_type.
-		$type = $this->sub_type;
+		if ( empty( $type ) ) {
+			$type = $this->sub_type;
+		}
 
 		if ( empty( $type ) ) {
 			return array();

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -22,13 +22,14 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	/**
 	 * Get a URL list for a taxonomy sitemap.
 	 *
-	 * @param int $page_num Page of results.
+	 * @param int    $page_num Page of results.
+	 * @param string $type     Optional. Taxonomy type name. Default ''.
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num, $type = null ) {
+	public function get_url_list( $page_num, $type = '' ) {
 		// Find the query_var for sub_type.
-		if ( empty( $type ) ) {
-			$type = $this->sub_type;
+		if ( ! $type ) {
+			$type = $this->get_queried_type();
 		}
 
 		if ( empty( $type ) ) {

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -26,7 +26,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * @param int $page_num Page of results.
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num ) {
+	public function get_url_list( $page_num, $type = null ) {
 		$object_type = $this->object_type;
 		$query       = $this->get_public_post_authors_query( $page_num );
 

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -23,15 +23,14 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	/**
 	 * Get a URL list for a user sitemap.
 	 *
-	 * @param int $page_num Page of results.
+	 * @param int    $page_num Page of results.
+	 * @param string $type     Optional. Not applicable for Users but required for
+	 *                         compatibility with the parent provider class. Default ''.
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num, $type = null ) {
-		$object_type = $this->object_type;
-		$query       = $this->get_public_post_authors_query( $page_num );
-
-		$users = $query->get_results();
-
+	public function get_url_list( $page_num, $type = '' ) {
+		$query    = $this->get_public_post_authors_query( $page_num );
+		$users    = $query->get_results();
 		$url_list = array();
 
 		foreach ( $users as $user ) {

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -89,8 +89,8 @@ class Core_Sitemaps {
 			if ( ! $sitemap instanceof Core_Sitemaps_Provider ) {
 				return;
 			}
-			add_rewrite_rule( $sitemap->route, $sitemap->rewrite_query(), 'top' );
-			add_action( 'template_redirect', array( $sitemap, 'render_sitemap' ) );
+
+			$sitemap->setup();
 		}
 	}
 

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -74,11 +74,8 @@ class Core_Sitemaps {
 		);
 
 		// Register each supported provider.
-		foreach ( $providers as $provider ) {
-			$sitemaps = $provider->get_sitemaps();
-			foreach ( $sitemaps as $sitemap ) {
-				$this->registry->add_sitemap( $sitemap, $provider );
-			}
+		foreach ( $providers as $name => $provider ) {
+			$this->registry->add_sitemap( $name, $provider );
 		}
 	}
 


### PR DESCRIPTION
This implements a performant way of showing `lastmod` values for sitemap pages in the sitemap index.

### Issue Number
This will fix #60.

### Description
It's not performant to calculate `lastmod` values dynamically when the site index is rendered, so this approach calculates the `lastmod` values asynchronously. `lastmod` values for each sitemap page is stored in an option with a key of `core_sitemaps_lasmod_{object-type}_{object-subtype}_{page_number}` which are checked whenever the sitemap index is rendered. If no value exists, a single job is scheduled to fill in that value. All values are updated twice daily rather than updating them dynamically each time a post, taxonomy archive, or user is changed.

The main changes include:

- Moves responsibility for storing sitemap pages from the registry to each sitemap provider (7a64d11), which also improves general performance.
- Calculate `lastmod` values asynchronously and store as options (7ee9014, 6b9bab6).
- Update all `lastmod` values via a scheduled task run twice daily (56c3c16, 4da5f94, and other cleanup).

### Type of change
Please select the relevant options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
- Visit the sitemap index for the first time to see that all lastmod values are empty.
- Run `wp cron event list` to see that events have been scheduled for calculating lastmod values.
- Wait for the events to run, or manually run `wp cron event run --all` to clear the scheduled events and see that `lastmod` values have been updated.

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have added test instructions that prove my fix is effective or that my feature works.
