### PR TITLE
Fix default types for max_num_pages.

### DIFF
--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -185,7 +185,7 @@ class Core_Sitemaps_Provider {
 	 * @param string $type Optional. Object type. Default is null.
 	 * @return int Total number of pages.
 	 */
-	public function max_num_pages( $type = null ) {
+	public function max_num_pages( $type = '' ) {
 		if ( empty( $type ) ) {
 			$type = $this->get_queried_type();
 		}

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -67,7 +67,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * @param string $type Optional. Name of the object type. Default is null.
 	 * @return int Total page count.
 	 */
-	public function max_num_pages( $type = null ) {
+	public function max_num_pages( $type = '' ) {
 		$query = $this->get_public_post_authors_query();
 
 		$total_users = $query->get_total();


### PR DESCRIPTION
This ensures all providers with `max_num_pages()` methods, consistently use an empty string instead of `null` as the default value.

### Issue Number
Related to #73.
