### PR TITLE
Add Unit tests for post type providers

### DIFF
--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -75,7 +75,8 @@ class Core_Sitemaps_Index {
 			$sitemaps = array();
 
 			foreach ( $providers as $provider ) {
-				$sitemaps = array_merge( $sitemaps, $provider->get_sitemap_entries() );
+				// Using array_push is more efficient than array_merge in a loop.
+				$sitemaps = array_push( $sitemaps, ...$provider->get_sitemap_entries() );
 			}
 
 			$this->renderer->render_index( $sitemaps );

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -119,10 +119,10 @@ class Core_Sitemaps_Provider {
 			$type = $this->get_queried_type();
 		}
 
-		// Return an empty array if the type is not public.
-		$public_types = get_post_types( array( 'public' => true ) );
+		// Return an empty array if the type is not supported.
+		$supported_types = $this->get_object_sub_types();
 
-		if ( ! in_array( $type, $public_types, true ) ) {
+		if ( ! isset( $supported_types[ $type ] ) ) {
 			return array();
 		}
 

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -119,6 +119,13 @@ class Core_Sitemaps_Provider {
 			$type = $this->get_queried_type();
 		}
 
+		// Return an empty array if the type is not public.
+		$public_types = get_post_types( array( 'public' => true ) );
+
+		if ( ! in_array( $type, $public_types, true ) ) {
+			return array();
+		}
+
 		$query = new WP_Query(
 			array(
 				'orderby'                => 'ID',

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -300,6 +300,30 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test sitemap index entries with public and private custom post types.
+	 *
+	 * @return void
+	 */
+	public function test_get_sitemap_entries_custom_post_types() {
+		// Register and create a public post type post.
+		register_post_type( 'public_cpt', array( 'public' => true ) );
+		$this->factory->post->create( array( 'post_type' => 'public_cpt' ) );
+
+		// Register and create a private post type post.
+		register_post_type( 'private_cpt', array( 'public' => false ) );
+		$this->factory->post->create( array( 'post_type' => 'private_cpt' ) );
+
+		$entries = wp_list_pluck( $this->_get_sitemap_entries(), 'loc' );
+
+		$this->assertTrue( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-public_cpt-1.xml', $entries, true ), 'Public CPTs are not in the index.' );
+		$this->assertFalse( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-private_cpt-1.xml', $entries, true ), 'Private CPTs are visible in the index.' );
+
+		// Clean up.
+		unregister_post_type( 'public_cpt' );
+		unregister_post_type( 'private_cpt' );
+	}
+
+	/**
 	 * Tests getting a URL list for post type post.
 	 */
 	public function test_get_url_list_post() {

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -25,11 +25,18 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	public static $users;
 
 	/**
-	 * List of term IDs.
+	 * List of post_tag IDs.
 	 *
 	 * @var array
 	 */
-	public static $terms;
+	public static $post_tags;
+
+	/**
+	 * List of category IDs.
+	 *
+	 * @var array
+	 */
+	public static $cats;
 
 	/**
 	 * List of post type post IDs.
@@ -51,10 +58,19 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory A WP_UnitTest_Factory object.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		self::$users = $factory->user->create_many( 10 );
-		self::$terms = $factory->term->create_many( 10 );
-		self::$posts = $factory->post->create_many( 10 );
-		self::$pages = $factory->post->create_many( 10, array( 'post_type' => 'page' ) );
+		self::$users     = $factory->user->create_many( 10 );
+		self::$post_tags = $factory->term->create_many( 10 );
+		self::$cats      = $factory->term->create_many( 10, array( 'taxonomy'  => 'category' ) );
+		self::$pages     = $factory->post->create_many( 10, array( 'post_type' => 'page' ) );
+
+		// Create a set of posts pre-assigned to tags and authors.
+		self::$posts = $factory->post->create_many(
+			10,
+			array(
+				'tags_input' => self::$post_tags,
+				'post_author' => reset( self::$users ),
+			)
+		);
 	}
 
 	/**

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -313,8 +313,8 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$entries = wp_list_pluck( $this->_get_sitemap_entries(), 'loc' );
 
-		$this->assertTrue( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-public_cpt-1.xml', $entries, true ), 'Public CPTs are not in the index.' );
-		$this->assertFalse( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-private_cpt-1.xml', $entries, true ), 'Private CPTs are visible in the index.' );
+		$this->assertContains( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-public_cpt-1.xml', $entries, 'Public CPTs are not in the index.' );
+		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-private_cpt-1.xml', $entries, 'Private CPTs are visible in the index.' );
 
 		// Clean up.
 		unregister_post_type( 'public_cpt' );

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -335,6 +335,9 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	 * Tests getting a URL list for post type page with included home page.
 	 */
 	public function test_get_url_list_page_with_home() {
+		// Create a new post to confirm the home page lastmod date.
+		$new_post = $this->factory->post->create_and_get();
+
 		$providers = core_sitemaps_get_sitemaps();
 
 		$post_list = $providers['posts']->get_url_list( 1, 'page' );
@@ -346,7 +349,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 			$expected,
 			array(
 				'loc'     => home_url(),
-				'lastmod' => end( $expected )['lastmod'],
+				'lastmod' => mysql2date( DATE_W3C, $new_post->post_modified_gmt, false ),
 			)
 		);
 

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -357,6 +357,28 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests getting a URL list for a custom post type.
+	 */
+	public function test_get_url_list_cpt() {
+		$post_type = 'custom_type';
+
+		register_post_type( $post_type );
+
+		$ids = $this->factory->post->create_many( 10, array( 'post_type' => $post_type ) );
+
+		$providers = core_sitemaps_get_sitemaps();
+
+		$post_list = $providers['posts']->get_url_list( 1, $post_type );
+
+		$expected = $this->_get_expected_url_list( $post_type, $ids );
+
+		$this->assertEquals( $expected, $post_list );
+
+		// Clean up.
+		unregister_post_type( $post_type );
+	}
+
+	/**
 	 * Helper function for building an expected url list.
 	 *
 	 * @param string $type An object sub type, e.g., post type.

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -217,6 +217,89 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper function to get all sitemap entries data.
+	 *
+	 * @return array A list of sitemap entires.
+	 */
+	public function _get_sitemap_entries() {
+		$entries   = array();
+
+		$providers = core_sitemaps_get_sitemaps();
+
+		foreach ( $providers as $provider ) {
+			$entries = array_merge( $entries, $provider->get_sitemap_entries() );
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Test default sitemap entries.
+	 */
+	public function test_get_sitemap_entries() {
+		$entries = $this->_get_sitemap_entries();
+
+		$expected = array(
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sub_type=post&paged=1',
+				'lastmod' => '',
+			),
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sub_type=page&paged=1',
+				'lastmod' => '',
+			),
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sub_type=category&paged=1',
+				'lastmod' => '',
+			),
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sub_type=post_tag&paged=1',
+				'lastmod' => '',
+			),
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=users&paged=1',
+				'lastmod' => '',
+			),
+		);
+
+		$this->assertSame( $expected, $entries );
+	}
+
+	/**
+	 * Test default sitemap entries with permalinks on.
+	 */
+	public function test_get_sitemap_entries_post_with_permalinks() {
+		$this->set_permalink_structure( '/%year%/%postname%/' );
+
+		$entries = $this->_get_sitemap_entries();
+
+		$expected = array(
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-post-1.xml',
+				'lastmod' => '',
+			),
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-page-1.xml',
+				'lastmod' => '',
+			),
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-category-1.xml',
+				'lastmod' => '',
+			),
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-post_tag-1.xml',
+				'lastmod' => '',
+			),
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-users-1.xml',
+				'lastmod' => '',
+			),
+		);
+
+		$this->assertSame( $expected, $entries );
+	}
+
+	/**
 	 * Tests getting a URL list for post type post.
 	 */
 	public function test_get_url_list_post() {

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -222,12 +222,13 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	 * @return array A list of sitemap entires.
 	 */
 	public function _get_sitemap_entries() {
-		$entries   = array();
+		$entries = array();
 
 		$providers = core_sitemaps_get_sitemaps();
 
 		foreach ( $providers as $provider ) {
-			$entries = array_merge( $entries, $provider->get_sitemap_entries() );
+			// Using `array_push` is more efficient than `array_merge` in the loop.
+			array_push( $entries, ...$provider->get_sitemap_entries() );
 		}
 
 		return $entries;

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -301,8 +301,6 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 	/**
 	 * Test sitemap index entries with public and private custom post types.
-	 *
-	 * @return void
 	 */
 	public function test_get_sitemap_entries_custom_post_types() {
 		// Register and create a public post type post.

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -80,13 +80,18 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		// Apply a filter to test filterable values.
 		add_filter( 'core_sitemaps_max_urls', array( $this, 'filter_max_url_value' ), 10, 2 );
 
-		$this->assertEquals( core_sitemaps_get_max_urls(), CORE_SITEMAPS_MAX_URLS, 'Can not confirm max URL number.' );
-		$this->assertEquals( core_sitemaps_get_max_urls( 'posts' ), 300, 'Can not confirm max URL number for posts.' );
-		$this->assertEquals( core_sitemaps_get_max_urls( 'taxonomies' ), 50, 'Can not confirm max URL number for taxonomies.' );
-		$this->assertEquals( core_sitemaps_get_max_urls( 'users' ), 1, 'Can not confirm max URL number for users.' );
+		$expected_null = core_sitemaps_get_max_urls();
+		$expected_posts = core_sitemaps_get_max_urls( 'posts' );
+		$expected_taxonomies = core_sitemaps_get_max_urls( 'taxonomies' );
+		$expected_users = core_sitemaps_get_max_urls( 'users' );
 
 		// Clean up.
 		remove_filter( 'core_sitemaps_max_urls', array( $this, 'filter_max_url_value' ) );
+
+		$this->assertEquals( $expected_null, CORE_SITEMAPS_MAX_URLS, 'Can not confirm max URL number.' );
+		$this->assertEquals( $expected_posts, 300, 'Can not confirm max URL number for posts.' );
+		$this->assertEquals( $expected_taxonomies, 50, 'Can not confirm max URL number for taxonomies.' );
+		$this->assertEquals( $expected_users, 1, 'Can not confirm max URL number for users.' );
 	}
 
 	/**
@@ -342,12 +347,12 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$entries = wp_list_pluck( $this->_get_sitemap_entries(), 'loc' );
 
-		$this->assertContains( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-public_cpt-1.xml', $entries, 'Public CPTs are not in the index.' );
-		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-private_cpt-1.xml', $entries, 'Private CPTs are visible in the index.' );
-
 		// Clean up.
 		unregister_post_type( 'public_cpt' );
 		unregister_post_type( 'private_cpt' );
+
+		$this->assertContains( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-public_cpt-1.xml', $entries, 'Public CPTs are not in the index.' );
+		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-private_cpt-1.xml', $entries, 'Private CPTs are visible in the index.' );
 	}
 
 	/**
@@ -376,10 +381,10 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$expected = $this->_get_expected_url_list( 'page', self::$pages );
 
-		$this->assertEquals( $expected, $post_list );
-
 		// Clean up.
 		remove_filter( 'pre_option_show_on_front', '__return_true' );
+
+		$this->assertEquals( $expected, $post_list );
 	}
 
 	/**
@@ -424,10 +429,10 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$expected = $this->_get_expected_url_list( $post_type, $ids );
 
-		$this->assertEquals( $expected, $post_list, 'Custom post type posts are not visible.' );
-
 		// Clean up.
 		unregister_post_type( $post_type );
+
+		$this->assertEquals( $expected, $post_list, 'Custom post type posts are not visible.' );
 	}
 
 	/**
@@ -445,10 +450,10 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$post_list = $providers['posts']->get_url_list( 1, $post_type );
 
-		$this->assertEmpty( $post_list, 'Private post types may be returned by the post provider.' );
-
 		// Clean up.
 		unregister_post_type( $post_type );
+
+		$this->assertEmpty( $post_list, 'Private post types may be returned by the post provider.' );
 	}
 
 	/**

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -305,11 +305,11 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	public function test_get_sitemap_entries_custom_post_types() {
 		// Register and create a public post type post.
 		register_post_type( 'public_cpt', array( 'public' => true ) );
-		$this->factory->post->create( array( 'post_type' => 'public_cpt' ) );
+		self::factory()->post->create( array( 'post_type' => 'public_cpt' ) );
 
 		// Register and create a private post type post.
 		register_post_type( 'private_cpt', array( 'public' => false ) );
-		$this->factory->post->create( array( 'post_type' => 'private_cpt' ) );
+		self::factory()->post->create( array( 'post_type' => 'private_cpt' ) );
 
 		$entries = wp_list_pluck( $this->_get_sitemap_entries(), 'loc' );
 
@@ -358,7 +358,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	 */
 	public function test_get_url_list_page_with_home() {
 		// Create a new post to confirm the home page lastmod date.
-		$new_post = $this->factory->post->create_and_get();
+		$new_post = self::factory()->post->create_and_get();
 
 		$providers = core_sitemaps_get_sitemaps();
 
@@ -387,7 +387,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		// Registered post types are private unless explicitly set to public.
 		register_post_type( $post_type, array( 'public' => true ) );
 
-		$ids = $this->factory->post->create_many( 10, array( 'post_type' => $post_type ) );
+		$ids = self::factory()->post->create_many( 10, array( 'post_type' => $post_type ) );
 
 		$providers = core_sitemaps_get_sitemaps();
 
@@ -410,7 +410,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		// Create a private post type for testing against data leaking.
 		register_post_type( $post_type, array( 'public' => false ) );
 
-		$this->factory->post->create_many( 10, array( 'post_type' => $post_type ) );
+		self::factory()->post->create_many( 10, array( 'post_type' => $post_type ) );
 
 		$providers = core_sitemaps_get_sitemaps();
 


### PR DESCRIPTION
### Issue Number
Related to #81.

### Description
Adds the following unit test methods:
- `test_get_sitemap_entries()` – Tests default entries for the index.
- `test_get_sitemap_entries_post_with_permalinks()` – Test default entries for the index with permalinks on.
- `test_get_sitemap_entries_custom_post_types()` – Tests that public and private CPTS are correctly included/excluded from the index list.
- `test_get_url_list_post()` – Tests the URL list for a post type post sitemap.
- `test_get_url_list_page()` – Tests the URL list for a post type page sitemap.
- `test_get_url_list_page_with_home()` – Tests the URL list for a post type page sitemap when the home page is the page for posts.
- `test_get_url_list_cpt()` – Tests the URL list for a public custom post type sitemap.
- `test_get_url_list_cpt_private()` – Tests the URL list for a private custom post type sitemap.


Also added:
- fixtures via the `wpSetUpBeforeClass()` method.
- helper method `_get_sitemap_entries()` - Returns all entries from all registered providers.
- helper method `_get_expected_url_list()` - Returns an expected URL list for a specific sitemap type.
- Fixes a few bugs found while building these tests.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Run the unit tests and see that they pass.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
