### PR TITLE
Add Unit tests for taxonomies

### DIFF
--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -37,8 +37,10 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 			return array();
 		}
 
+		$supported_types = $this->get_object_sub_types();
+
 		// Bail early if the queried taxonomy is not a supported type.
-		if ( ! in_array( $type, $this->get_object_sub_types() ) ) {
+		if ( ! isset( $supported_types[ $type ] ) ) {
 			return array();
 		}
 
@@ -111,7 +113,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 * Return all public, registered taxonomies.
 	 */
 	public function get_object_sub_types() {
-		$taxonomy_types = get_taxonomies( array( 'public' => true ) );
+		$taxonomy_types = get_taxonomies( array( 'public' => true ), 'objects' );
 
 		/**
 		 * Filter the list of taxonomy object sub types available within the sitemap.

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -32,7 +32,13 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 			$type = $this->get_queried_type();
 		}
 
+		// Bail early if we don't have a taxonomy type.
 		if ( empty( $type ) ) {
+			return array();
+		}
+
+		// Bail early if the queried taxonomy is not a supported type.
+		if ( ! in_array( $type, $this->get_object_sub_types() ) ) {
 			return array();
 		}
 
@@ -105,14 +111,14 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 * Return all public, registered taxonomies.
 	 */
 	public function get_object_sub_types() {
-		$taxonomy_types = get_taxonomies( array( 'public' => true ), 'objects' );
+		$taxonomy_types = get_taxonomies( array( 'public' => true ) );
 
 		/**
 		 * Filter the list of taxonomy object sub types available within the sitemap.
 		 *
 		 * @since 0.1.0
 		 *
-		 * @param array $taxonomy_types List of registered object sub types.
+		 * @param array $taxonomy_types List of registered taxonomy type names.
 		 */
 		return apply_filters( 'core_sitemaps_taxonomies', $taxonomy_types );
 	}

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -357,12 +357,12 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$entries = wp_list_pluck( $this->_get_sitemap_entries(), 'loc' );
 
-		$this->assertTrue( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-public_taxonomy-1.xml', $entries, true ), 'Public Taxonomies are not in the index.' );
-		$this->assertFalse( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-private_taxonomy-1.xml', $entries, true ), 'Private Taxonomies are visible in the index.' );
-
 		// Clean up.
 		unregister_taxonomy_for_object_type( 'public_taxonomy', 'post' );
 		unregister_taxonomy_for_object_type( 'private_taxonomy', 'post' );
+
+		$this->assertTrue( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-public_taxonomy-1.xml', $entries, true ), 'Public Taxonomies are not in the index.' );
+		$this->assertFalse( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-private_taxonomy-1.xml', $entries, true ), 'Private Taxonomies are visible in the index.' );
 	}
 
 	/**
@@ -544,10 +544,10 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$post_list = $tax_provider->get_url_list( 1, $taxonomy );
 
-		$this->assertEquals( $expected, $post_list, 'Custom taxonomy term links are not visible.' );
-
 		// Clean up.
 		unregister_taxonomy_for_object_type( $taxonomy, 'post' );
+
+		$this->assertEquals( $expected, $post_list, 'Custom taxonomy term links are not visible.' );
 	}
 
 	/**
@@ -571,10 +571,10 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$post_list = $tax_provider->get_url_list( 1, $taxonomy );
 
-		$this->assertEmpty( $post_list, 'Private taxonomy term links are visible.' );
-
 		// Clean up.
 		unregister_taxonomy_for_object_type( $taxonomy, 'post' );
+
+		$this->assertEmpty( $post_list, 'Private taxonomy term links are visible.' );
 	}
 
 	/**

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -433,6 +433,53 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test getting a URL list for default taxonomies via
+	 * Core_Sitemaps_Taxonomies::get_url_list().
+	 */
+	public function test_get_url_list_taxonomies() {
+		// Add the default category to the list of categories we're testing.
+		$categories = array_merge( array( 1 ), self::$cats );
+
+		// Create a test post to calculate update times.
+		$post = $this->factory->post->create_and_get(
+			array(
+				'tags_input' => self::$post_tags,
+				'post_category' => $categories,
+			)
+		);
+
+		$tax_provider = new Core_Sitemaps_Taxonomies();
+
+		$cat_list  = $tax_provider->get_url_list( 1, 'category' );
+
+		$expected_cats = array_map(
+			function ( $id ) use ( $post ) {
+				return array(
+					'loc'     => get_term_link( $id, 'category' ),
+					'lastmod' => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
+				);
+			},
+			$categories
+		);
+
+		$this->assertSame( $expected_cats, $cat_list, 'Category URL list does not match.' );
+
+		$tag_list = $tax_provider->get_url_list( 1, 'post_tag' );
+
+		$expected_tags = array_map(
+			function ( $id ) use ( $post ) {
+				return array(
+					'loc'     => get_term_link( $id, 'post_tag' ),
+					'lastmod' => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
+				);
+			},
+			self::$post_tags
+		);
+
+		$this->assertSame( $expected_tags, $tag_list, 'Post Tags URL list does not match.' );
+	}
+
+	/**
 	 * Test getting a URL list for a custom taxonomy via
 	 * Core_Sitemaps_Taxonomies::get_url_list().
 	 */

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -357,8 +357,8 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$entries = wp_list_pluck( $this->_get_sitemap_entries(), 'loc' );
 
-		$this->assertTrue( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-' . 'public_taxonomy' . '-1.xml', $entries, true ), 'Public Taxonomies are not in the index.' );
-		$this->assertFalse( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-' . 'private_taxonomy' . '-1.xml', $entries, true ), 'Private Taxonomies are visible in the index.' );
+		$this->assertTrue( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-public_taxonomy-1.xml', $entries, true ), 'Public Taxonomies are not in the index.' );
+		$this->assertFalse( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-private_taxonomy-1.xml', $entries, true ), 'Private Taxonomies are visible in the index.' );
 
 		// Clean up.
 		unregister_taxonomy_for_object_type( 'public_taxonomy', 'post' );

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -342,11 +342,11 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		register_taxonomy( 'private_taxonomy', 'post', array( 'public' => false ) );
 
 		// Create test terms in the custom taxonomy.
-		$public_term  = $this->factory->term->create( array( 'taxonomy'  => 'public_taxonomy' ) );
-		$private_term = $this->factory->term->create( array( 'taxonomy'  => 'private_taxonomy' ) );
+		$public_term  = self::factory()->term->create( array( 'taxonomy'  => 'public_taxonomy' ) );
+		$private_term = self::factory()->term->create( array( 'taxonomy'  => 'private_taxonomy' ) );
 
 		// Create a test post applied to all test terms.
-		$this->factory->post->create_and_get(
+		self::factory()->post->create_and_get(
 			array(
 				'tax_input' => array(
 					'public_taxonomy'  => array( $public_term ),
@@ -475,7 +475,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		$categories = array_merge( array( 1 ), self::$cats );
 
 		// Create a test post to calculate update times.
-		$post = $this->factory->post->create_and_get(
+		$post = self::factory()->post->create_and_get(
 			array(
 				'tags_input' => self::$post_tags,
 				'post_category' => $categories,
@@ -525,10 +525,10 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		register_taxonomy( $taxonomy, 'post' );
 
 		// Create test terms in the custom taxonomy.
-		$terms = $this->factory->term->create_many( 10, array( 'taxonomy'  => $taxonomy ) );
+		$terms = self::factory()->term->create_many( 10, array( 'taxonomy'  => $taxonomy ) );
 
 		// Create a test post applied to all test terms.
-		$post = $this->factory->post->create_and_get( array( 'tax_input' => array( $taxonomy => $terms ) ) );
+		$post = self::factory()->post->create_and_get( array( 'tax_input' => array( $taxonomy => $terms ) ) );
 
 		$expected = array_map(
 			function ( $id ) use ( $taxonomy, $post ) {
@@ -562,10 +562,10 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		register_taxonomy( $taxonomy, 'post', array( 'public' => false ) );
 
 		// Create test terms in the custom taxonomy.
-		$terms = $this->factory->term->create_many( 10, array( 'taxonomy'  => $taxonomy ) );
+		$terms = self::factory()->term->create_many( 10, array( 'taxonomy'  => $taxonomy ) );
 
 		// Create a test post applied to all test terms.
-		$this->factory->post->create( array( 'tax_input' => array( $taxonomy => $terms ) ) );
+		self::factory()->post->create( array( 'tax_input' => array( $taxonomy => $terms ) ) );
 
 		$tax_provider = new Core_Sitemaps_Taxonomies();
 

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -453,16 +453,15 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 			function ( $id ) use ( $taxonomy, $post ) {
 				return array(
 					'loc'     => get_term_link( $id, $taxonomy ),
-					'lastmod' => mysql2date( DATE_W3C, $post->post_modified_gmt, false )
+					'lastmod' => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
 				);
 			},
 			$terms
 		);
 
-		$tax_provider = new Core_Sitemaps_Taxonomies;
+		$tax_provider = new Core_Sitemaps_Taxonomies();
 
 		$post_list = $tax_provider->get_url_list( 1, $taxonomy );
-
 
 		$this->assertEquals( $expected, $post_list, 'Custom taxonomy term links are not visible.' );
 
@@ -487,7 +486,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		// Create a test post applied to all test terms.
 		$this->factory->post->create( array( 'tax_input' => array( $taxonomy => $terms ) ) );
 
-		$tax_provider = new Core_Sitemaps_Taxonomies;
+		$tax_provider = new Core_Sitemaps_Taxonomies();
 
 		$post_list = $tax_provider->get_url_list( 1, $taxonomy );
 


### PR DESCRIPTION
### Issue Number
Related to #81.
~Blocked by #94.~

### Description
This adds several unit tests methods related to taxonomies.

- Adds method `test_get_url_list_custom_taxonomy()` that tests that custom taxonomies are returned by `Core_Sitemaps_Taxonomies::get_url_list()`
- Adds method `test_get_url_list_custom_taxonomy_private()` that tests that private custom taxonomies are _not_ returned by `Core_Sitemaps_Taxonomies::get_url_list()`
- Fixes a bug which allowed `Core_Sitemaps_Taxonomies::get_url_list()` to return non-public data
- Adds method `test_get_url_list_taxonomies()` which ensures that default taxonomy sitemaps include expected URL lists.
- Adds method `test_get_sitemap_entries_custom_taxonomies()`, which assures public custom taxonomies are included in the sitemap index and that private custom taxonomies are not.

### Screenshots (before and after if applicable)
If your PR includes visual changes include before and after screenshots showing the change.

### Type of change
Please select the relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
