### PR TITLE
Add unit tests for users provider

### DIFF
--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -578,6 +578,34 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test getting a URL list for a users sitemap page via
+	 * Core_Sitemaps_Users::get_url_list().
+	 */
+	public function test_get_url_list_users() {
+		// Set up the user to an editor to assign posts to other users.
+		wp_set_current_user( self::$editor_id );
+
+		// Create a set of posts for each user and generate the expected URL list data.
+		$expected = array_map(
+			function ( $user_id ) {
+				$post = $this->factory->post->create_and_get( array( 'post_author' => $user_id ) );
+
+				return array(
+					'loc'      => get_author_posts_url( $user_id ),
+					'lastmod' => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
+				);
+			},
+			self::$users
+		);
+
+		$user_provider = new Core_Sitemaps_Users();
+
+		$url_list = $user_provider->get_url_list( 1 );
+
+		$this->assertSame( $expected, $url_list );
+	}
+
+	/**
 	 * Helper function for building an expected url list.
 	 *
 	 * @param string $type An object sub type, e.g., post type.

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -588,7 +588,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		// Create a set of posts for each user and generate the expected URL list data.
 		$expected = array_map(
 			function ( $user_id ) {
-				$post = $this->factory->post->create_and_get( array( 'post_author' => $user_id ) );
+				$post = self::factory()->post->create_and_get( array( 'post_author' => $user_id ) );
 
 				return array(
 					'loc'      => get_author_posts_url( $user_id ),


### PR DESCRIPTION
This adds test method `test_get_url_list_users()` which ensures the correct URL list is generated by `Core_Sitemaps_Users::get_url_list()`.

### Issue Number
Related to #81.
~Blocked by #95.~

### Description
This adds test method `test_get_url_list_users()` which ensures the correct URL list is generated by `Core_Sitemaps_Users::get_url_list()`.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
