### PR TITLE
Fix robots.txt output and add unit tests.

### DIFF
--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -84,6 +84,23 @@ class Core_Sitemaps_Index {
 	}
 
 	/**
+	 * Builds the URL for the sitemap index.
+	 *
+	 * @return string the sitemap index url.
+	 */
+	public function get_index_url() {
+		global $wp_rewrite;
+
+		$url = home_url( '/sitemap.xml' );
+
+		if ( ! $wp_rewrite->using_permalinks() ) {
+			$url = add_query_arg( 'sitemap', 'index', home_url( '/' ) );
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Adds the sitemap index to robots.txt.
 	 *
 	 * @param string $output robots.txt output.
@@ -92,7 +109,7 @@ class Core_Sitemaps_Index {
 	 */
 	public function add_robots( $output, $public ) {
 		if ( $public ) {
-			$output .= 'Sitemap: ' . esc_url( $this->renderer->get_sitemap_url( $this->name ) ) . "\n";
+			$output .= 'Sitemap: ' . esc_url( $this->get_index_url() ) . "\n";
 		}
 
 		return $output;

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -167,7 +167,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		$robots_text = apply_filters( 'robots_txt', '', true );
 		$sitemap_string = 'Sitemap: http://' . WP_TESTS_DOMAIN . '/?sitemap=index';
 
-		$this->assertTrue( false !== strpos( $robots_text, $sitemap_string ), 'Sitemap URL not included in robots text.' );
+		$this->assertNotFalse( strpos( $robots_text, $sitemap_string ), 'Sitemap URL not included in robots text.' );
 	}
 
 	/**
@@ -181,7 +181,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		$robots_text = apply_filters( 'robots_txt', '', true );
 		$sitemap_string = 'Sitemap: http://' . WP_TESTS_DOMAIN . '/sitemap.xml';
 
-		$this->assertTrue( false !== strpos( $robots_text, $sitemap_string ), 'Sitemap URL not included in robots text.' );
+		$this->assertNotFalse( strpos( $robots_text, $sitemap_string ), 'Sitemap URL not included in robots text.' );
 
 		// Clean up permalinks.
 		$this->set_permalink_structure();

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -159,5 +159,31 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		$this->assertSame( $expected, $xml, 'Sitemap page markup incorrect.' );
 	}
 
+	/**
+	 * Test robots.txt output.
+	 */
+	public function test_robots_text() {
+		// Get the text added to the default robots text output.
+		$robots_text = apply_filters( 'robots_txt', '', true );
+		$sitemap_string = 'Sitemap: http://' . WP_TESTS_DOMAIN . '/?sitemap=index';
 
+		$this->assertTrue( false !== strpos( $robots_text, $sitemap_string ), 'Sitemap URL not included in robots text.' );
+	}
+
+	/**
+	 * Test robots.txt output with permalinks set.
+	 */
+	public function test_robots_text_with_permalinks() {
+		// Set permalinks for testing.
+		$this->set_permalink_structure( '/%year%/%postname%/' );
+
+		// Get the text added to the default robots text output.
+		$robots_text = apply_filters( 'robots_txt', '', true );
+		$sitemap_string = 'Sitemap: http://' . WP_TESTS_DOMAIN . '/sitemap.xml';
+
+		$this->assertTrue( false !== strpos( $robots_text, $sitemap_string ), 'Sitemap URL not included in robots text.' );
+
+		// Clean up permalinks.
+		$this->set_permalink_structure();
+	}
 }

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -181,9 +181,9 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		$robots_text = apply_filters( 'robots_txt', '', true );
 		$sitemap_string = 'Sitemap: http://' . WP_TESTS_DOMAIN . '/sitemap.xml';
 
-		$this->assertNotFalse( strpos( $robots_text, $sitemap_string ), 'Sitemap URL not included in robots text.' );
-
 		// Clean up permalinks.
 		$this->set_permalink_structure();
+
+		$this->assertNotFalse( strpos( $robots_text, $sitemap_string ), 'Sitemap URL not included in robots text.' );
 	}
 }


### PR DESCRIPTION
This adds unit tests for ensuring the sitemap index is added to the robots.txt output. This test initially exposed that this functionality was broken, so this also fixes the broken behavior.

### Issue Number
Related to #81 and #34.

### Description
Adds test methods:

- `test_robots_text()` - Ensures the sitemap index URL is included in `robots_txt` filter output.
- `test_robots_text_with_permalinks()` - Ensures the sitemap index URL is included in `robots_txt` filter output with permalinks on.

Fixes:

- Adds `Core_Sitemaps_Index::get_index_url()` generates the URL output for the sitemap index, which is displayed in robots.txt.
- Updates `Core_Sitemaps_Index::add_robots()` to use the `get_index_url()` method, which was originally in #34 but had sense been removed.

### Screenshots (before and after if applicable)
If your PR includes visual changes include before and after screenshots showing the change.

### Type of change
Please select the relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
