### PR TITLE
Unit tests: Fix permalink structure leakage between tests.

### DIFF
--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -340,6 +340,9 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 			),
 		);
 
+		// Clean up permalinks.
+		$this->set_permalink_structure();
+
 		$this->assertSame( $expected, $entries );
 	}
 
@@ -361,8 +364,8 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		unregister_post_type( 'public_cpt' );
 		unregister_post_type( 'private_cpt' );
 
-		$this->assertContains( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-public_cpt-1.xml', $entries, 'Public CPTs are not in the index.' );
-		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-private_cpt-1.xml', $entries, 'Private CPTs are visible in the index.' );
+		$this->assertContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sub_type=public_cpt&paged=1', $entries, 'Public CPTs are not in the index.' );
+		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sub_type=private_cpt&paged=1', $entries, 'Private CPTs are visible in the index.' );
 	}
 
 	/**
@@ -395,8 +398,8 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		unregister_taxonomy_for_object_type( 'public_taxonomy', 'post' );
 		unregister_taxonomy_for_object_type( 'private_taxonomy', 'post' );
 
-		$this->assertTrue( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-public_taxonomy-1.xml', $entries, true ), 'Public Taxonomies are not in the index.' );
-		$this->assertFalse( in_array( 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-private_taxonomy-1.xml', $entries, true ), 'Private Taxonomies are visible in the index.' );
+		$this->assertTrue( in_array( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sub_type=public_taxonomy&paged=1', $entries, true ), 'Public Taxonomies are not in the index.' );
+		$this->assertFalse( in_array( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sub_type=private_taxonomy&paged=1', $entries, true ), 'Private Taxonomies are visible in the index.' );
 	}
 
 	/**


### PR DESCRIPTION
### Issue Number
Related to #81.

### Description
This resets the permalink structure that gets set in the `test_get_sitemap_entries_post_with_permalinks()` method which was polluting other tests that rely on the permalinks structure being set. Affected tests have also been updated.

### Type of change
Please select the relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
