### PR TITLE
Add extra attributes to sitemap entries.

### DIFF
--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -181,7 +181,7 @@ class Core_Sitemaps_Provider {
 		 * @param string $type     Name of the post_type.
 		 * @param int    $page_num Page of results.
 		 */
-		return apply_filters( 'core_sitemaps_post_url_list', $url_list, $type, $page_num );
+		return apply_filters( 'core_sitemaps_posts_url_list', $url_list, $type, $page_num );
 	}
 
 	/**

--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -128,8 +128,15 @@ class Core_Sitemaps_Renderer {
 
 		foreach ( $url_list as $url_item ) {
 			$url = $urlset->addChild( 'url' );
-			$url->addChild( 'loc', esc_url( $url_item['loc'] ) );
-			$url->addChild( 'lastmod', esc_attr( $url_item['lastmod'] ) );
+
+			// Add each attribute as a child node to the URL entry.
+			foreach ( $url_item as $attr => $value ) {
+				if ( 'url' === $attr ) {
+					$url->addChild( $attr, esc_url( $value ) );
+				} else {
+					$url->addChild( $attr, esc_attr( $value ) );
+				}
+			}
 		}
 
 		return $urlset->asXML();


### PR DESCRIPTION
- Ensures each provider's `get_url_list()` method can be filtered to add attributes to sitemap entries.
- Ensures extra attributes passed to the renderer's `get_sitemap_xml()` method will be included in rendered output.

Unit test methods added:

- `test_core_sitemaps_xml_extra_atts()` – tests the rendered XML output.
- `test_add_attributes_to_url_list()` – tests filtered URL lists from each provider.

Changes include:

- Renamed filter `core_sitemaps_post_url_list` to `core_sitemaps_posts_url_list` to consistently use the object type in filter names.
- Updated `Core_Sitemaps_Renderer::get_sitemap_xml()` to include extra attributes in rendered XML markup.

### Issue Number
Closes #88.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Filter the URL list from any provider using a callback like:

```
add_filter( 'core_sitemaps_posts_url_list', function ( $url_list ) {
	return array_map(
		function ( $entry ) {
			$entry['extra'] = 'value';
			return $entry;
		},
		$url_list
	);
} );
```

And see that the sitemap entries now include a new value in the rendered XML markup.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
