### PR TITLE
Fix gathering sitemap entries before rendering the index.

### DIFF
--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -76,7 +76,7 @@ class Core_Sitemaps_Index {
 
 			foreach ( $providers as $provider ) {
 				// Using array_push is more efficient than array_merge in a loop.
-				$sitemaps = array_push( $sitemaps, ...$provider->get_sitemap_entries() );
+				array_push( $sitemaps, ...$provider->get_sitemap_entries() );
 			}
 
 			$this->renderer->render_index( $sitemaps );


### PR DESCRIPTION
### Description
This fixes a bug introduced in d1a826c, which caused sitemap entries to be an empty list before sending them to the renderer in `Core_Sitemaps_Index ::render_sitemap()`.

### Type of change
Please select the relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Before applying this branch the main XML file should not include any sitemap entries. Applying this branch causes them all to be displayed again.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
