### PR TITLE
Merge pull request #104 from GoogleChromeLabs/feature/87-add-sitemaps

### DIFF
--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -77,6 +77,13 @@ class Core_Sitemaps {
 		foreach ( $providers as $name => $provider ) {
 			$this->registry->add_sitemap( $name, $provider );
 		}
+
+		/**
+		 * Fires after core sitemaps are registered.
+		 *
+		 * @since 0.1.0
+		 */
+		do_action( 'core_sitemaps_register' );
 	}
 
 	/**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -13,9 +13,20 @@
 function core_sitemaps_get_sitemaps() {
 	global $core_sitemaps;
 
-	$sitemaps = $core_sitemaps->registry->get_sitemaps();
+	return $core_sitemaps->registry->get_sitemaps();
+}
 
-	return $sitemaps;
+/**
+ * Register a new sitemap provider.
+ *
+ * @param string                 $name     Unique name for the sitemap provider.
+ * @param Core_Sitemaps_Provider $provider The `Core_Sitemaps_Provider` instance implementing the sitemap.
+ * @return bool Returns true if the sitemap was added. False on failure.
+ */
+function core_sitemaps_register_sitemap( $name, $provider ) {
+	global $core_sitemaps;
+
+	return $core_sitemaps->registry->add_sitemap( $name, $provider );
 }
 
 /**

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -9,6 +9,9 @@
  */
 
 use WP_UnitTestCase;
+use Core_Sitemaps_Test_Provider;
+
+require_once( __DIR__ . '/inc/class-core-sitemaps-test-provider.php' );
 
 /**
  * Core sitemaps test cases.
@@ -60,6 +63,13 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	public static $editor_id;
 
 	/**
+	 * Test sitemap provider.
+	 *
+	 * @var Core_Sitemaps_Test_Provider
+	 */
+	public static $test_provider;
+
+	/**
 	 * Set up fixtures.
 	 *
 	 * @param WP_UnitTest_Factory $factory A WP_UnitTest_Factory object.
@@ -81,6 +91,8 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		// Create a user with an editor role to complete some tests.
 		self::$editor_id  = $factory->user->create( array( 'role' => 'editor' ) );
+
+		self::$test_provider = new Core_Sitemaps_Test_Provider();
 	}
 
 	/**
@@ -752,5 +764,16 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 			},
 			$posts
 		);
+	}
+
+	/**
+	 * Test functionality that adds a new sitemap provider to the registry.
+	 */
+	public function test_register_sitemap_provider() {
+		core_sitemaps_register_sitemap( 'test_sitemap', self::$test_provider );
+
+		$sitemaps = core_sitemaps_get_sitemaps();
+
+		$this->assertEquals( $sitemaps['test_sitemap'], self::$test_provider, 'Can not confirm sitemap registration is working.' );
 	}
 }

--- a/tests/phpunit/inc/class-core-sitemaps-test-provider.php
+++ b/tests/phpunit/inc/class-core-sitemaps-test-provider.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Test sitemap provider.
+ *
+ * @package Core_Sitemaps
+ */
+
+/**
+ * Class Core_Sitemaps_Test_Provider.
+ *
+ * Provides test data for additional registered providers.
+ */
+class Core_Sitemaps_Test_Provider extends Core_Sitemaps_Provider {
+	/**
+	 * Core_Sitemaps_Posts constructor.
+	 */
+	public function __construct() {
+		$this->object_type = 'test';
+		$this->route       = '^sitemap-test-([A-z]+)-?([0-9]+)?\.xml$';
+		$this->slug        = 'test';
+	}
+
+	/**
+	 * Return the public post types, which excludes nav_items and similar types.
+	 * Attachments are also excluded. This includes custom post types with public = true
+	 *
+	 * @return array $post_types List of registered object sub types.
+	 */
+	public function get_object_sub_types() {
+		return array( 'type-1', 'type-2', 'type-3' );
+	}
+
+}


### PR DESCRIPTION
This allows for adding new sitemaps to the system using a new `core_sitemaps_register_sitemap()` helper function.

Added:

- `core_sitemaps_register_sitemap()` – Used to register a new sitemap provider.
- Hook `core_sitemaps_register` – Fires after core sitemaps are registered so new sitemaps can be added or additional actions can be taken.
- `Core_Sitemaps_Tests::test_register_sitemap_provider` – test method to confirm registered sitemaps are included in the registry.
- `Core_Sitemaps_Test_Provider` class used in the PHPUnit test suite.

### Issue Number
Closes #87.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Add a new callback on the `core_sitemaps_register` hook that registers a new sitemap provider and see that it shows up in the list of sitemaps. For example:

```
add_action( 'core_sitemaps_register', function () {
	core_sitemaps_register_sitemap( 'test', new Core_Sitemaps_Provider() );

	var_dump( core_sitemaps_get_sitemaps() );
	die();

} );
```

You should see that a sitemap named 'test' is included in the list of providers.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
