### PR TITLE
Consolidate rewrites and rendering

### DIFF
--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -20,33 +20,12 @@ class Core_Sitemaps_Index {
 	protected $name = 'index';
 
 	/**
-	 * Renderer class.
-	 *
-	 * @var Core_Sitemaps_Renderer
-	 */
-	protected $renderer;
-
-	/**
-	 * Core_Sitemaps_Index constructor.
-	 */
-	public function __construct() {
-		$this->renderer = new Core_Sitemaps_Renderer();
-	}
-
-	/**
 	 * A helper function to initiate actions, hooks and other features needed.
 	 */
 	public function setup_sitemap() {
-		// Set up rewrites.
-		add_rewrite_tag( '%sitemap%', '([^?]+)' );
-		add_rewrite_rule( '^sitemap\.xml$', 'index.php?sitemap=index', 'top' );
-
 		// Add filters.
 		add_filter( 'robots_txt', array( $this, 'add_robots' ), 0, 2 );
 		add_filter( 'redirect_canonical', array( $this, 'redirect_canonical' ) );
-
-		// Add actions.
-		add_action( 'template_redirect', array( $this, 'render_sitemap' ) );
 	}
 
 	/**
@@ -61,27 +40,6 @@ class Core_Sitemaps_Index {
 		}
 
 		return $redirect;
-	}
-
-	/**
-	 * Produce XML to output.
-	 */
-	public function render_sitemap() {
-		$sitemap_index = get_query_var( 'sitemap' );
-
-		if ( 'index' === $sitemap_index ) {
-			$providers = core_sitemaps_get_sitemaps();
-
-			$sitemaps = array();
-
-			foreach ( $providers as $provider ) {
-				// Using array_push is more efficient than array_merge in a loop.
-				array_push( $sitemaps, ...$provider->get_sitemap_entries() );
-			}
-
-			$this->renderer->render_index( $sitemaps );
-			exit;
-		}
 	}
 
 	/**

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -196,6 +196,18 @@ class Core_Sitemaps_Provider {
 	}
 
 	/**
+	 * Set the object sub_type.
+	 *
+	 * @param string $sub_type The name of the object subtype.
+	 * @return bool Returns true on success.
+	 */
+	public function set_sub_type( $sub_type ) {
+		$this->sub_type = $sub_type;
+
+		return true;
+	}
+
+	/**
 	 * Get data about each sitemap type.
 	 *
 	 * @return array List of sitemap types including object subtype name and number of pages.

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -46,10 +46,6 @@ class Core_Sitemaps_Provider {
 	 * Set up relevant rewrite rules, actions, and filters.
 	 */
 	public function setup() {
-		// Set up rewrite rules and rendering callback.
-		add_rewrite_rule( $this->route, $this->rewrite_query(), 'top' );
-		add_action( 'template_redirect', array( $this, 'render_sitemap' ) );
-
 		// Set up async tasks related to calculating lastmod data.
 		add_action( 'core_sitemaps_calculate_lastmod', array( $this, 'calculate_sitemap_lastmod' ), 10, 3 );
 		add_action( 'core_sitemaps_update_lastmod_' . $this->slug, array( $this, 'update_lastmod_values' ) );
@@ -68,42 +64,6 @@ class Core_Sitemaps_Provider {
 			$lastmod_recurrence = apply_filters( 'core_sitemaps_lastmod_recurrence', 'twicedaily', $this->slug );
 
 			wp_schedule_event( time(), $lastmod_recurrence, 'core_sitemaps_update_lastmod_' . $this->slug );
-		}
-	}
-
-	/**
-	 * Print the XML to output for a sitemap.
-	 */
-	public function render_sitemap() {
-		global $wp_query;
-
-		$sitemap  = sanitize_text_field( get_query_var( 'sitemap' ) );
-		$sub_type = sanitize_text_field( get_query_var( 'sub_type' ) );
-		$paged    = absint( get_query_var( 'paged' ) );
-
-		if ( $this->slug === $sitemap ) {
-			if ( empty( $paged ) ) {
-				$paged = 1;
-			}
-
-			$sub_types = $this->get_object_sub_types();
-
-			// Only set the current object sub-type if it's supported.
-			if ( isset( $sub_types[ $sub_type ] ) ) {
-				$this->sub_type = $sub_types[ $sub_type ]->name;
-			}
-
-			$url_list = $this->get_url_list( $paged );
-
-			// Force a 404 and bail early if no URLs are present.
-			if ( empty( $url_list ) ) {
-				$wp_query->set_404();
-				return;
-			}
-
-			$renderer = new Core_Sitemaps_Renderer();
-			$renderer->render_sitemap( $url_list );
-			exit;
 		}
 	}
 

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -201,16 +201,20 @@ class Core_Sitemaps {
 			$sub_types = $provider->get_object_sub_types();
 
 			// Only set the current object sub-type if it's supported.
-			$sub_type = isset( $sub_types[ $sub_type ] ) ? $sub_type : '';
+			if ( isset( $sub_types[ $sub_type ] ) ) {
+				$provider->set_sub_type( $sub_types[ $sub_type ]->name );
+			}
 
 			$url_list = $provider->get_url_list( $paged, $sub_type );
+
+			// Force a 404 and bail early if no URLs are present.
+			if ( empty( $url_list ) ) {
+				$wp_query->set_404();
+				return;
+			}
 
 			$this->renderer->render_sitemap( $url_list );
 			exit;
 		}
-
-		// If this is reached, an invalid sitemap URL was requested.
-		$wp_query->set_404();
-		return;
 	}
 }


### PR DESCRIPTION
### Issue Number
Blocked by #87. Once that is merged, this should be updated to point to 'master'.

### Description
This consolidates redundant functionality for registering rewrites and rendering files from individual providers and makes them a concern of the main Core_Sitemaps class.

Changes:

- Adds a new `renderer` property to `Core_Sitemaps`, which references a `Core_Sitemaps_Renderer` object.
- Removes references to `Core_Sitemaps_Renderer` objects from the `Core_Sitemaps_Index` and `Core_Sitemaps_Provider` objects.
- Moves all registration of rewrite tags and routes to a new `Core_Sitemaps::register_rewrites()` method.
- Consolidates all `template_redirect` rendering callbacks to a single `Core_Sitemaps::render_sitemaps()`.
- Renames `Core_Sitemaps::xsl_stylesheet_rewrites()` to `Core_Sitemaps::register_xsl_rewrites()` to be more declarative and match the new `Core_Sitemaps::register_rewrites()` method.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
All unit tests are still passing and sitemap pages are being rendered as expected.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
