### PR TITLE
Initialize Core Sitemaps system on the init hook.

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -43,7 +43,5 @@ require_once __DIR__ . '/inc/class-core-sitemaps-taxonomies.php';
 require_once __DIR__ . '/inc/class-core-sitemaps-users.php';
 require_once __DIR__ . '/inc/functions.php';
 
-global $core_sitemaps;
-
-$core_sitemaps = new Core_Sitemaps();
-$core_sitemaps->bootstrap();
+// Boot the sitemaps system.
+add_action( 'init', 'core_sitemaps_get_server' );

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -38,11 +38,14 @@ class Core_Sitemaps {
 	 *
 	 * @return void
 	 */
-	public function bootstrap() {
-		add_action( 'init', array( $this, 'setup_sitemaps_index' ) );
-		add_action( 'init', array( $this, 'register_sitemaps' ) );
-		add_action( 'init', array( $this, 'setup_sitemaps' ) );
-		add_action( 'init', array( $this, 'xsl_stylesheet_rewrites' ) );
+	public function init() {
+		// These will all fire on the init hook.
+		$this->setup_sitemaps_index();
+		$this->register_sitemaps();
+
+		// Add additional action callbacks.
+		add_action( 'core_sitemaps_init', array( $this, 'xsl_stylesheet_rewrites' ) );
+		add_action( 'core_sitemaps_init', array( $this, 'setup_sitemaps' ) );
 		add_action( 'wp_loaded', array( $this, 'maybe_flush_rewrites' ) );
 	}
 
@@ -77,13 +80,6 @@ class Core_Sitemaps {
 		foreach ( $providers as $name => $provider ) {
 			$this->registry->add_sitemap( $name, $provider );
 		}
-
-		/**
-		 * Fires after core sitemaps are registered.
-		 *
-		 * @since 0.1.0
-		 */
-		do_action( 'core_sitemaps_register' );
 	}
 
 	/**

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -52,7 +52,6 @@ class Core_Sitemaps {
 		$this->register_sitemaps();
 
 		// Add additional action callbacks.
-		add_action( 'core_sitemaps_init', array( $this, 'xsl_stylesheet_rewrites' ) );
 		add_action( 'core_sitemaps_init', array( $this, 'setup_sitemaps' ) );
 		add_action( 'core_sitemaps_init', array( $this, 'register_rewrites' ) );
 		add_action( 'core_sitemaps_init', array( $this, 'register_xsl_rewrites' ) );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -6,12 +6,45 @@
  */
 
 /**
+ * Retrieves the current Sitemaps server instance.
+ *
+ * @return Core_Sitemaps Core_Sitemaps instance.
+ */
+function core_sitemaps_get_server() {
+	/**
+	 * Global Core Sitemaps instance.
+	 *
+	 * @var Core_Sitemaps $core_sitemaps
+	 */
+	global $core_sitemaps;
+
+	// If there isn't a global instance, set and bootstrap the sitemaps system.
+	if ( empty( $core_sitemaps ) ) {
+		$core_sitemaps = new Core_Sitemaps();
+		$core_sitemaps->init();
+
+		/**
+		 * Fires when initializing the Core_Sitemaps object.
+		 *
+		 * Additional sitemaps should be registered on this hook.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param core_sitemaps $core_sitemaps Server object.
+		 */
+		do_action( 'core_sitemaps_init', $core_sitemaps );
+	}
+
+	return $core_sitemaps;
+}
+
+/**
  * Get a list of sitemaps.
  *
  * @return array $sitemaps A list of registered sitemap providers.
  */
 function core_sitemaps_get_sitemaps() {
-	global $core_sitemaps;
+	$core_sitemaps = core_sitemaps_get_server();
 
 	return $core_sitemaps->registry->get_sitemaps();
 }
@@ -24,7 +57,7 @@ function core_sitemaps_get_sitemaps() {
  * @return bool Returns true if the sitemap was added. False on failure.
  */
 function core_sitemaps_register_sitemap( $name, $provider ) {
-	global $core_sitemaps;
+	$core_sitemaps = core_sitemaps_get_server();
 
 	return $core_sitemaps->registry->add_sitemap( $name, $provider );
 }


### PR DESCRIPTION
### Issue Number
Blocked by #104 and will need to be updated once #105 is merged.

### Description
This creates a new helper function for getting the global `Core_Sitemaps` instance and uses this function to initialize the whole system via the WordPress `init` hook.

Changes:

- Adds `core_sitemaps_get_server()`, which returns the global instance of `Core_Sitemaps` system and initialize one if none already exists.
- Adds `core_sitemaps_init` action that fires after the global `Core_Sitemaps` object is initialized.
- Renames `Core_Sitemaps::bootstrap()` to `Core_Sitemaps::init()` to reinforce that it fires on the init hook.
- Updates the firing/registration of callbacks that formerly were registered in `Core_Sitemaps::bootstrap()`
- Updates all helper functions that were referencing the global $core_sitemaps object to use `core_sitemaps_get_server()` instead.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
