### PR TITLE
Merge pull request #108 from TangRufus/robot-txt-sitemap-line-feed

### DIFF
--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -110,7 +110,7 @@ class Core_Sitemaps_Index {
 	 */
 	public function add_robots( $output, $public ) {
 		if ( $public ) {
-			$output .= 'Sitemap: ' . esc_url( $this->get_index_url() ) . "\n";
+			$output .= "\nSitemap: " . esc_url( $this->get_index_url() ) . "\n";
 		}
 
 		return $output;

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -356,6 +356,17 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test robots.txt output with line feed prefix.
+	 */
+	public function test_robots_text_prefixed_with_line_feed() {
+		// Get the text added to the default robots text output.
+		$robots_text = apply_filters( 'robots_txt', '', true );
+		$sitemap_string = "\nSitemap: ";
+
+		$this->assertNotFalse( strpos( $robots_text, $sitemap_string ), 'Sitemap URL not prefixed with "\n".' );
+	}
+
+	/**
 	 * Helper function to get all sitemap entries data.
 	 *
 	 * @return array A list of sitemap entires.


### PR DESCRIPTION
### Issue Number
A link to the original issue in Github that this PR aims to fix.

### Description

To avoid issues when previous `robots_txt` callback forgets to add `\n` suffix.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test

1. Add this filter to break `robots.txt`:

    ```php
    add_filter('robots_txt', function ($output) {
       $output .= 'I am a line without line break';
       return $output;
    }, -1, 1);
    ```

2. Visit `xxx.com/robots.txt`

Before this PR:

```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
I am a line without line breakSitemap: http://xxx.com/xyz
```


After this PR:

```
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php
I am a line without line break
Sitemap: http://xxx.com/xyz
```

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
