### PR TITLE
Add unfilterable `wp-` prefix to sitemaps

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -27,7 +27,7 @@
 
 // The limit for how many sitemaps to include in an index.
 const CORE_SITEMAPS_MAX_SITEMAPS    = 50000;
-const CORE_SITEMAPS_REWRITE_VERSION = '2019-11-15a';
+const CORE_SITEMAPS_REWRITE_VERSION = '2020-03-03';
 
 // Limit the number of URLs included in as sitemap.
 if ( ! defined( 'CORE_SITEMAPS_MAX_URLS' ) ) {

--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -53,7 +53,7 @@ class Core_Sitemaps_Index {
 	public function get_index_url() {
 		global $wp_rewrite;
 
-		$url = home_url( '/sitemap.xml' );
+		$url = home_url( '/wp-sitemap.xml' );
 
 		if ( ! $wp_rewrite->using_permalinks() ) {
 			$url = add_query_arg( 'sitemap', 'index', home_url( '/' ) );

--- a/inc/class-core-sitemaps-posts.php
+++ b/inc/class-core-sitemaps-posts.php
@@ -18,7 +18,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	 */
 	public function __construct() {
 		$this->object_type = 'post';
-		$this->route       = '^sitemap-posts-([A-z]+)-?([0-9]+)?\.xml$';
+		$this->route       = '^wp-sitemap-posts-([A-z]+)-?([0-9]+)?\.xml$';
 		$this->slug        = 'posts';
 	}
 

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -277,7 +277,7 @@ class Core_Sitemaps_Provider {
 		global $wp_rewrite;
 
 		$basename = sprintf(
-			'/sitemap-%1$s.xml',
+			'/wp-sitemap-%1$s.xml',
 			// Accounts for cases where name is not included, ex: sitemaps-users-1.xml.
 			implode( '-', array_filter( array( $this->slug, $name, (string) $page ) ) )
 		);

--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -43,7 +43,7 @@ class Core_Sitemaps_Renderer {
 	 * @return string the sitemap stylesheet url.
 	 */
 	public function get_sitemap_stylesheet_url() {
-		$sitemap_url = home_url( 'sitemap.xsl' );
+		$sitemap_url = home_url( '/wp-sitemap.xsl' );
 
 		/**
 		 * Filter the URL for the sitemap stylesheet.
@@ -59,7 +59,7 @@ class Core_Sitemaps_Renderer {
 	 * @return string the sitemap index stylesheet url.
 	 */
 	public function get_sitemap_index_stylesheet_url() {
-		$sitemap_url = home_url( 'sitemap-index.xsl' );
+		$sitemap_url = home_url( '/wp-sitemap-index.xsl' );
 
 		/**
 		 * Filter the URL for the sitemap index stylesheet.

--- a/inc/class-core-sitemaps-taxonomies.php
+++ b/inc/class-core-sitemaps-taxonomies.php
@@ -18,7 +18,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 */
 	public function __construct() {
 		$this->object_type = 'taxonomy';
-		$this->route       = '^sitemap-taxonomies-([A-z]+)-?([0-9]+)?\.xml$';
+		$this->route       = '^wp-sitemap-taxonomies-([A-z]+)-?([0-9]+)?\.xml$';
 		$this->slug        = 'taxonomies';
 	}
 

--- a/inc/class-core-sitemaps-users.php
+++ b/inc/class-core-sitemaps-users.php
@@ -18,7 +18,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 */
 	public function __construct() {
 		$this->object_type = 'user';
-		$this->route       = '^sitemap-users-?([0-9]+)?\.xml$';
+		$this->route       = '^wp-sitemap-users-?([0-9]+)?\.xml$';
 		$this->slug        = 'users';
 	}
 

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -118,7 +118,7 @@ class Core_Sitemaps {
 		add_rewrite_tag( '%sub_type%', '([^?]+)' );
 
 		// Register index route.
-		add_rewrite_rule( '^sitemap\.xml$', 'index.php?sitemap=index', 'top' );
+		add_rewrite_rule( '^wp-sitemap\.xml$', 'index.php?sitemap=index', 'top' );
 
 		// Register routes for providers.
 		$providers = core_sitemaps_get_sitemaps();
@@ -133,8 +133,8 @@ class Core_Sitemaps {
 	 */
 	public function register_xsl_rewrites() {
 		add_rewrite_tag( '%stylesheet%', '([^?]+)' );
-		add_rewrite_rule( '^sitemap\.xsl$', 'index.php?stylesheet=xsl', 'top' );
-		add_rewrite_rule( '^sitemap-index\.xsl$', 'index.php?stylesheet=index', 'top' );
+		add_rewrite_rule( '^wp-sitemap\.xsl$', 'index.php?stylesheet=xsl', 'top' );
+		add_rewrite_rule( '^wp-sitemap-index\.xsl$', 'index.php?stylesheet=index', 'top' );
 	}
 
 	/**

--- a/tests/phpunit/class-test-core-sitemaps.php
+++ b/tests/phpunit/class-test-core-sitemaps.php
@@ -161,23 +161,23 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 	public function test_core_sitemaps_index_xml() {
 		$entries = array(
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-post-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml',
 				'lastmod' => '2019-11-01T12:00:00+00:00',
 			),
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-page-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-page-1.xml',
 				'lastmod' => '2019-11-01T12:00:10+00:00',
 			),
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-category-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-category-1.xml',
 				'lastmod' => '2019-11-01T12:00:20+00:00',
 			),
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-post_tag-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-post_tag-1.xml',
 				'lastmod' => '2019-11-01T12:00:30+00:00',
 			),
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-users-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-users-1.xml',
 				'lastmod' => '2019-11-01T12:00:40+00:00',
 			),
 		);
@@ -187,13 +187,13 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		$xml = $renderer->get_sitemap_index_xml( $entries );
 
 		$expected = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL .
-		'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/sitemap-index.xsl" ?>' . PHP_EOL .
+		'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/wp-sitemap-index.xsl" ?>' . PHP_EOL .
 		'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
-		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/sitemap-posts-post-1.xml</loc><lastmod>2019-11-01T12:00:00+00:00</lastmod></sitemap>' .
-		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/sitemap-posts-page-1.xml</loc><lastmod>2019-11-01T12:00:10+00:00</lastmod></sitemap>' .
-		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-category-1.xml</loc><lastmod>2019-11-01T12:00:20+00:00</lastmod></sitemap>' .
-		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-post_tag-1.xml</loc><lastmod>2019-11-01T12:00:30+00:00</lastmod></sitemap>' .
-		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/sitemap-users-1.xml</loc><lastmod>2019-11-01T12:00:40+00:00</lastmod></sitemap>' .
+		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml</loc><lastmod>2019-11-01T12:00:00+00:00</lastmod></sitemap>' .
+		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-page-1.xml</loc><lastmod>2019-11-01T12:00:10+00:00</lastmod></sitemap>' .
+		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-category-1.xml</loc><lastmod>2019-11-01T12:00:20+00:00</lastmod></sitemap>' .
+		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-post_tag-1.xml</loc><lastmod>2019-11-01T12:00:30+00:00</lastmod></sitemap>' .
+		'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-users-1.xml</loc><lastmod>2019-11-01T12:00:40+00:00</lastmod></sitemap>' .
 		'</sitemapindex>' . PHP_EOL;
 
 		$this->assertSame( $expected, $xml, 'Sitemap index markup incorrect.' );
@@ -231,7 +231,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 		$xml = $renderer->get_sitemap_xml( $url_list );
 
 		$expected = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL .
-		'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/sitemap.xsl" ?>' . PHP_EOL .
+		'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/wp-sitemap.xsl" ?>' . PHP_EOL .
 		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
 		'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-1</loc><lastmod>2019-11-01T12:00:00+00:00</lastmod></url>' .
 		'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-2</loc><lastmod>2019-11-01T12:00:10+00:00</lastmod></url>' .
@@ -347,7 +347,7 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		// Get the text added to the default robots text output.
 		$robots_text = apply_filters( 'robots_txt', '', true );
-		$sitemap_string = 'Sitemap: http://' . WP_TESTS_DOMAIN . '/sitemap.xml';
+		$sitemap_string = 'Sitemap: http://' . WP_TESTS_DOMAIN . '/wp-sitemap.xml';
 
 		// Clean up permalinks.
 		$this->set_permalink_structure();
@@ -426,23 +426,23 @@ class Core_Sitemaps_Tests extends WP_UnitTestCase {
 
 		$expected = array(
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-post-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml',
 				'lastmod' => '',
 			),
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-posts-page-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-page-1.xml',
 				'lastmod' => '',
 			),
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-category-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-category-1.xml',
 				'lastmod' => '',
 			),
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-taxonomies-post_tag-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-post_tag-1.xml',
 				'lastmod' => '',
 			),
 			array(
-				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/sitemap-users-1.xml',
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-users-1.xml',
 				'lastmod' => '',
 			),
 		);


### PR DESCRIPTION
### Issue Number
Fixes #128.

### Description
Adds unfilterable `wp-` prefix to sitemaps

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Describe the tests required to verify your changes.
Provide instructions so the PR Tester can check functionality and also list any relevant details and / or dependencies required for your tests.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [x] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
