### PR TITLE
Use wp_die when SimpleXML is not available

### DIFF
--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -92,7 +92,12 @@ class Core_Sitemaps_Renderer {
 		header( 'Content-type: application/xml; charset=UTF-8' );
 
 		if ( ! class_exists( 'SimpleXMLElement' ) ) {
-			add_filter( 'wp_die_handler', static function() { return '_xml_wp_die_handler'; } );
+			add_filter(
+				'wp_die_handler',
+				static function () {
+					return '_xml_wp_die_handler';
+				}
+			);
 
 			wp_die(
 				sprintf(
@@ -100,9 +105,9 @@ class Core_Sitemaps_Renderer {
 					__( 'Could not generate XML sitemap due to missing %s extension', 'core-sitemaps' ),
 					'SimpleXML'
 				),
-				__( 'WordPress &rsaquo; Error' ),
+				__( 'WordPress &rsaquo; Error', 'core-sitemaps' ),
 				array(
-					'response' => 501 // Not implemented
+					'response' => 501, // "Not implemented".
 				)
 			);
 		}

--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -91,6 +91,22 @@ class Core_Sitemaps_Renderer {
 	public function render_index( $sitemaps ) {
 		header( 'Content-type: application/xml; charset=UTF-8' );
 
+		if ( ! class_exists( 'SimpleXMLElement' ) ) {
+			add_filter( 'wp_die_handler', static function() { return '_xml_wp_die_handler'; } );
+
+			wp_die(
+				sprintf(
+					/* translators: %s: SimpleXML */
+					__( 'Could not generate XML sitemap due to missing %s extension', 'core-sitemaps' ),
+					'SimpleXML'
+				),
+				__( 'WordPress &rsaquo; Error' ),
+				array(
+					'response' => 501 // Not implemented
+				)
+			);
+		}
+
 		$index_xml = $this->get_sitemap_index_xml( $sitemaps );
 
 		if ( ! empty( $index_xml ) ) {

--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -91,26 +91,7 @@ class Core_Sitemaps_Renderer {
 	public function render_index( $sitemaps ) {
 		header( 'Content-type: application/xml; charset=UTF-8' );
 
-		if ( ! class_exists( 'SimpleXMLElement' ) ) {
-			add_filter(
-				'wp_die_handler',
-				static function () {
-					return '_xml_wp_die_handler';
-				}
-			);
-
-			wp_die(
-				sprintf(
-					/* translators: %s: SimpleXML */
-					__( 'Could not generate XML sitemap due to missing %s extension', 'core-sitemaps' ),
-					'SimpleXML'
-				),
-				__( 'WordPress &rsaquo; Error', 'core-sitemaps' ),
-				array(
-					'response' => 501, // "Not implemented".
-				)
-			);
-		}
+		$this->check_for_simple_xml_availability();
 
 		$index_xml = $this->get_sitemap_index_xml( $sitemaps );
 
@@ -147,6 +128,8 @@ class Core_Sitemaps_Renderer {
 	public function render_sitemap( $url_list ) {
 		header( 'Content-type: application/xml; charset=UTF-8' );
 
+		$this->check_for_simple_xml_availability();
+
 		$sitemap_xml = $this->get_sitemap_xml( $url_list );
 
 		if ( ! empty( $sitemap_xml ) ) {
@@ -179,5 +162,31 @@ class Core_Sitemaps_Renderer {
 		}
 
 		return $urlset->asXML();
+	}
+
+	/**
+	 * Checks for the availability of the SimpleXML extension and errors if missing.
+	 */
+	private function check_for_simple_xml_availability() {
+		if ( ! class_exists( 'SimpleXMLElement' ) ) {
+			add_filter(
+				'wp_die_handler',
+				static function () {
+					return '_xml_wp_die_handler';
+				}
+			);
+
+			wp_die(
+				sprintf(
+				/* translators: %s: SimpleXML */
+					__( 'Could not generate XML sitemap due to missing %s extension', 'core-sitemaps' ),
+					'SimpleXML'
+				),
+				__( 'WordPress &rsaquo; Error', 'core-sitemaps' ),
+				array(
+					'response' => 501, // "Not implemented".
+				)
+			);
+		}
 	}
 }


### PR DESCRIPTION
### Issue Number

Fixes #122.

### Description

Uses `wp_die()` when the SimpleXML extension is not available.

### Screenshots (before and after if applicable)

![Screenshot 2020-03-05 at 15 49 04](https://user-images.githubusercontent.com/841956/75992915-001d2880-5ef9-11ea-9662-1b22571820b3.png)

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test

Disable extension or temporarily tweak code to trigger the error message.

Not sure how feasible/worthwhile a CI integration is. But it might be possible to disable the extension there:

https://docs.travis-ci.com/user/languages/php/#disabling-preinstalled-php-extensions

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [x] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
