### PR TITLE
Redirect sitemap.xml to wp-sitemap.xml if about to return a 404

### DIFF
--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -58,6 +58,7 @@ class Core_Sitemaps {
 		add_action( 'core_sitemaps_init', array( $this, 'register_rewrites' ) );
 		add_action( 'template_redirect', array( $this, 'render_sitemaps' ) );
 		add_action( 'wp_loaded', array( $this, 'maybe_flush_rewrites' ) );
+		add_action( 'pre_handle_404', array( $this, 'redirect_sitemapxml' ), 10, 2 );
 	}
 
 	/**
@@ -230,6 +231,28 @@ class Core_Sitemaps {
 
 			$this->renderer->render_sitemap( $url_list );
 			exit;
+		}
+	}
+
+	/**
+	 * Redirect an URL to the wp-sitemap.xml
+	 *
+	 * @param bool     $bypass Pass-through of the pre_handle_404 filter value.
+	 * @param WP_Query $query The WP_Query object.
+	 */
+	public function redirect_sitemapxml( $bypass, $query ) {
+		global $wp_rewrite;
+
+		// If a plugin has already utilized the pre_handle_404 function, return without action to avoid conflicts.
+		if ( $bypass ) {
+			return $bypass;
+		}
+
+		// 'pagename' is for most permalink types, name is for when the %postname% is used as a top-level field.
+		if ( 'sitemap-xml' === $query->get( 'pagename' ) ||
+			 'sitemap-xml' === $query->get( 'name' ) ) {
+			wp_safe_redirect( $this->index->get_index_url() );
+			exit();
 		}
 	}
 }

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -241,8 +241,6 @@ class Core_Sitemaps {
 	 * @param WP_Query $query The WP_Query object.
 	 */
 	public function redirect_sitemapxml( $bypass, $query ) {
-		global $wp_rewrite;
-
 		// If a plugin has already utilized the pre_handle_404 function, return without action to avoid conflicts.
 		if ( $bypass ) {
 			return $bypass;


### PR DESCRIPTION
### Issue Number
Fixes #144 

### Description
`sitemap.xml` is a common location of a site's sitemap. In instances where there is not an existing sitemap.xml either on the file system or served by another plugin, the Core WP-Sitemaps plugin will redirect to the wp-sitemap.xml URL to help improve discoverability and allowed those who have submitted `sitemap.xml` to search engines to be able to drop-in without change.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
* Visit your testing site's sitemap.xml (assuming your server is set to have WP serve that URL, e.g. with pretty permalinks on with .htaccess set for Apache or via the server block in Nginx).
* On master, a WP-served 404 will be returned.
* On this branch, it will 302 redirect to `wp-sitemap.xml`


### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [x] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
