### PR TITLE
Allow turning off XML stylesheets via stylesheet URL filters

### DIFF
--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -31,10 +31,24 @@ class Core_Sitemaps_Renderer {
 	 * Core_Sitemaps_Renderer constructor.
 	 */
 	public function __construct() {
-		$stylesheet_url         = $this->get_sitemap_stylesheet_url();
-		$stylesheet_index_url   = $this->get_sitemap_index_stylesheet_url();
-		$this->stylesheet       = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_url ) . '" ?>';
-		$this->stylesheet_index = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_index_url ) . '" ?>';
+		/**
+		 * Filter whether the XSLT stylesheet is used when the sitemap is viewed in a browser.
+		 *
+		 * @param bool $use_stylesheet True if the XSLT stylesheet should be used, false otherwise.
+		 */
+		if ( apply_filters( 'core_sitemaps_use_stylesheet', true ) ) {
+			$stylesheet_url   = $this->get_sitemap_stylesheet_url();
+			$this->stylesheet = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_url ) . '" ?>';
+		}
+		/**
+		 * Filter whether the XSLT stylesheet is used when the sitemap index is viewed in a browser.
+		 *
+		 * @param bool $use_stylesheet True if the XSLT stylesheet should be used, false otherwise.
+		 */
+		if ( apply_filters( 'core_sitemaps_use_index_stylesheet', true ) ) {
+			$stylesheet_index_url   = $this->get_sitemap_index_stylesheet_url();
+			$this->stylesheet_index = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_index_url ) . '" ?>';
+		}
 	}
 
 	/**
@@ -109,7 +123,14 @@ class Core_Sitemaps_Renderer {
 	 * @return string|false A well-formed XML string for a sitemap index. False on error.
 	 */
 	public function get_sitemap_index_xml( $sitemaps ) {
-		$sitemap_index = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8" ?>' . $this->stylesheet_index . '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>' );
+		$sitemap_index = new SimpleXMLElement(
+			sprintf(
+				'%1$s%2$s%3$s',
+				'<?xml version="1.0" encoding="UTF-8" ?>',
+				$this->stylesheet_index,
+				'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" />'
+			)
+		);
 
 		foreach ( $sitemaps as $entry ) {
 			$sitemap = $sitemap_index->addChild( 'sitemap' );
@@ -146,7 +167,14 @@ class Core_Sitemaps_Renderer {
 	 * @return string|false A well-formed XML string for a sitemap index. False on error.
 	 */
 	public function get_sitemap_xml( $url_list ) {
-		$urlset = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8" ?>' . $this->stylesheet . '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>' );
+		$urlset = new SimpleXMLElement(
+			sprintf(
+				'%1$s%2$s%3$s',
+				'<?xml version="1.0" encoding="UTF-8" ?>',
+				$this->stylesheet,
+				'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" />'
+			)
+		);
 
 		foreach ( $url_list as $url_item ) {
 			$url = $urlset->addChild( 'url' );

--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -31,22 +31,12 @@ class Core_Sitemaps_Renderer {
 	 * Core_Sitemaps_Renderer constructor.
 	 */
 	public function __construct() {
-		/**
-		 * Filter whether the XSLT stylesheet is used when the sitemap is viewed in a browser.
-		 *
-		 * @param bool $use_stylesheet True if the XSLT stylesheet should be used, false otherwise.
-		 */
-		if ( apply_filters( 'core_sitemaps_use_stylesheet', true ) ) {
-			$stylesheet_url   = $this->get_sitemap_stylesheet_url();
+		$stylesheet_url = $this->get_sitemap_stylesheet_url();
+		if ( $stylesheet_url ) {
 			$this->stylesheet = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_url ) . '" ?>';
 		}
-		/**
-		 * Filter whether the XSLT stylesheet is used when the sitemap index is viewed in a browser.
-		 *
-		 * @param bool $use_stylesheet True if the XSLT stylesheet should be used, false otherwise.
-		 */
-		if ( apply_filters( 'core_sitemaps_use_index_stylesheet', true ) ) {
-			$stylesheet_index_url   = $this->get_sitemap_index_stylesheet_url();
+		$stylesheet_index_url   = $this->get_sitemap_index_stylesheet_url();
+		if ( $stylesheet_index_url ) {
 			$this->stylesheet_index = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_index_url ) . '" ?>';
 		}
 	}

--- a/inc/class-core-sitemaps-renderer.php
+++ b/inc/class-core-sitemaps-renderer.php
@@ -59,6 +59,9 @@ class Core_Sitemaps_Renderer {
 		/**
 		 * Filter the URL for the sitemap stylesheet.
 		 *
+		 * If a falsy value is returned, no stylesheet will be used and
+		 * the "raw" XML of the sitemap will be displayed.
+		 *
 		 * @param string $sitemap_url Full URL for the sitemaps xsl file.
 		 */
 		return apply_filters( 'core_sitemaps_stylesheet_url', $sitemap_url );
@@ -81,6 +84,9 @@ class Core_Sitemaps_Renderer {
 
 		/**
 		 * Filter the URL for the sitemap index stylesheet.
+		 *
+		 * If a falsy value is returned, no stylesheet will be used and
+		 * the "raw" XML of the sitemap index will be displayed.
 		 *
 		 * @param string $sitemap_url Full URL for the sitemaps index xsl file.
 		 */


### PR DESCRIPTION
### Issue Number
#154

### Description

Applies the filters in `Core_Sitemaps_Renderer:__construct()` to control whether `$this->stylesheet` and `$this->stylesheet_index` get initialized to the `xml-stylesheet` PIs.

### Screenshots (before and after if applicable)

When the filter returns true (as before):

![filter-returns-true](https://user-images.githubusercontent.com/3824560/79079087-28ebc700-7cca-11ea-944e-17aba02cc1b5.png)

When the filter returns false:

![filter-returns-false](https://user-images.githubusercontent.com/3824560/79079096-3bfe9700-7cca-11ea-8f06-f795b745dc52.png)

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test

To disable both the index and sitemap stylesheets, do:

```
add_filter( 'core_sitemaps_use_stylesheet', '__return_false' );
add_filter( 'core_sitemaps_use_index_stylesheet', '__return_false' );
```
### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [X] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
