### PR TITLE
Improve unit tests

### DIFF
--- a/tests/assets/normalize-xml.xsl
+++ b/tests/assets/normalize-xml.xsl
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!--
+	Normalize an XML document to make it easier to compare whether 2 documents will
+	be seen as "equal" to an XML processor.
+
+	The normalization is similiar, in spirit, to {@link https://www.w3.org/TR/xml-c14n11/ Canonical XML},
+	but without some aspects of C14N that make the kinds of assertions we need difficult.
+
+	For example, the following XML documents will be interpreted the same by an XML processor,
+	even though a string comparison of them would show differences:
+
+	<root xmlns='urn:example'>
+		<ns0:child xmlns:ns0='urn:another-example'>this is a test</ns0:child>
+	</root>
+
+	<ns0:root xmlns:ns0='urn:example'>
+		<child xmlns='urn:another-example'>this is a test</child>
+	</ns0:root>
+  -->
+<xsl:transform
+		xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
+		version='1.0'
+	>
+
+	<!--
+		Output UTF-8 XML, no indendation and all CDATA sections replaced with their character content. 
+	  -->
+	<xsl:output
+		method='xml'
+		indent='no'
+		cdata-section-elements=''
+		encoding='UTF-8' />
+
+	<!--
+		Strip insignificant white space.
+	  -->
+	<xsl:strip-space elements='*' />
+
+	<!--
+		Noramlize elements by not relying on the prefix used in the input document
+		and ordering attributes first by namespace-uri and then by local-name.
+	  -->
+	<xsl:template match='*' priority='10'>
+		<xsl:element name='{local-name()}' namespace='{namespace-uri()}'>
+			<xsl:apply-templates select='@*'>
+				<xsl:sort select='namespace-uri()' />
+				<xsl:sort select='local-name()' />
+			</xsl:apply-templates>
+
+			<xsl:apply-templates select='node()' />
+		</xsl:element>
+	</xsl:template>
+
+	<!--
+		Noramlize attributes by not relying on the prefix used in the input document.
+	  -->
+	<xsl:template match='@*'>
+		<xsl:attribute name='{local-name()}' namespace='{namespace-uri()}'>
+			<xsl:value-of select='.' />
+		</xsl:attribute>
+	</xsl:template>
+
+	<!--
+		Strip comments. 
+	  -->
+	<xsl:template match='comment()' priority='10' />
+
+	<!--
+		Pass all other nodes through unchanged.  
+	  -->
+	<xsl:template match='node()'>
+		<xsl:copy>
+			<xsl:apply-templates select='node()' />
+		</xsl:copy>
+	</xsl:template>
+</xsl:transform>

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -102,8 +102,8 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 
 		$renderer = new Core_Sitemaps_Renderer();
 
-		$xmlDom   = $this->loadXML( $renderer->get_sitemap_index_xml( $entries ) );
-		$xpath    = new DOMXPath( $xmlDom );
+		$xml_dom   = $this->loadXML( $renderer->get_sitemap_index_xml( $entries ) );
+		$xpath    = new DOMXPath( $xml_dom );
 
 		$this->assertCount(
 			0,
@@ -170,8 +170,8 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 
 		$renderer = new Core_Sitemaps_Renderer();
 
-		$xmlDom   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
-		$xpath    = new DOMXPath( $xmlDom );
+		$xml_dom   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
+		$xpath    = new DOMXPath( $xml_dom );
 
 		$this->assertCount(
 			0,
@@ -201,8 +201,8 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 
 		$renderer = new Core_Sitemaps_Renderer();
 
-		$xmlDom   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
-		$xpath    = new DOMXPath( $xmlDom );
+		$xml_dom   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
+		$xpath    = new DOMXPath( $xml_dom );
 		$xpath->registerNamespace( 'sitemap', 'http://www.sitemaps.org/schemas/sitemap/0.9' );
 
 		$this->assertEquals(
@@ -247,10 +247,10 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$internal = libxml_use_internal_errors( true );
 		libxml_clear_errors();
 
-		$xmlDom = new DOMDocument();
+		$xml_dom = new DOMDocument();
 
 		$this->assertTrue(
-			$xmlDom->loadXML( $xml, $options ),
+			$xml_dom->loadXML( $xml, $options ),
 			libxml_get_last_error() ? sprintf( 'Non-well-formed XML: %s.', libxml_get_last_error()->message ) : ''
 		);
 
@@ -258,7 +258,7 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		libxml_use_internal_errors( $internal );
 		libxml_clear_errors();
 
-		return $xmlDom;
+		return $xml_dom;
 	}
 
 	/**

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -110,8 +110,6 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 			$xpath->query( '//processing-instruction( "xml-stylesheet" )' ),
 			'Sitemap incorrectly contains the xml-stylesheet processing instruction.'
 		);
-
-		return;
 	}
 
 	/**
@@ -180,8 +178,6 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 			$xpath->query( '//processing-instruction( "xml-stylesheet" )' ),
 			'Sitemap incorrectly contains the xml-stylesheet processing instruction.'
 		);
-
-		return;
 	}
 
 	/**

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -51,23 +51,18 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$entries = array(
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml',
-				'lastmod' => '2019-11-01T12:00:00+00:00',
 			),
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-page-1.xml',
-				'lastmod' => '2019-11-01T12:00:10+00:00',
 			),
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-category-1.xml',
-				'lastmod' => '2019-11-01T12:00:20+00:00',
 			),
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-post_tag-1.xml',
-				'lastmod' => '2019-11-01T12:00:30+00:00',
 			),
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-users-1.xml',
-				'lastmod' => '2019-11-01T12:00:40+00:00',
 			),
 		);
 
@@ -77,11 +72,11 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$expected = '<?xml version="1.0" encoding="UTF-8"?>' .
 					'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/?sitemap-stylesheet=index" ?>' .
 					'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
-					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml</loc><lastmod>2019-11-01T12:00:00+00:00</lastmod></sitemap>' .
-					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-page-1.xml</loc><lastmod>2019-11-01T12:00:10+00:00</lastmod></sitemap>' .
-					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-category-1.xml</loc><lastmod>2019-11-01T12:00:20+00:00</lastmod></sitemap>' .
-					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-post_tag-1.xml</loc><lastmod>2019-11-01T12:00:30+00:00</lastmod></sitemap>' .
-					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-users-1.xml</loc><lastmod>2019-11-01T12:00:40+00:00</lastmod></sitemap>' .
+					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml</loc></sitemap>' .
+					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-page-1.xml</loc></sitemap>' .
+					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-category-1.xml</loc></sitemap>' .
+					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-post_tag-1.xml</loc></sitemap>' .
+					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-users-1.xml</loc></sitemap>' .
 					'</sitemapindex>';
 
 		$this->assertXMLEquals( $expected, $actual, 'Sitemap index markup incorrect.' );
@@ -94,7 +89,6 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$entries = array(
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml',
-				'lastmod' => '2019-11-01T12:00:00+00:00',
 			),
 		);
 
@@ -119,23 +113,18 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$url_list = array(
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-1',
-				'lastmod' => '2019-11-01T12:00:00+00:00',
 			),
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-2',
-				'lastmod' => '2019-11-01T12:00:10+00:00',
 			),
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-3',
-				'lastmod' => '2019-11-01T12:00:20+00:00',
 			),
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-4',
-				'lastmod' => '2019-11-01T12:00:30+00:00',
 			),
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-5',
-				'lastmod' => '2019-11-01T12:00:40+00:00',
 			),
 		);
 
@@ -145,11 +134,11 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$expected = '<?xml version="1.0" encoding="UTF-8"?>' .
 					'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/?sitemap-stylesheet=xsl" ?>' .
 					'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
-					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-1</loc><lastmod>2019-11-01T12:00:00+00:00</lastmod></url>' .
-					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-2</loc><lastmod>2019-11-01T12:00:10+00:00</lastmod></url>' .
-					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-3</loc><lastmod>2019-11-01T12:00:20+00:00</lastmod></url>' .
-					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-4</loc><lastmod>2019-11-01T12:00:30+00:00</lastmod></url>' .
-					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-5</loc><lastmod>2019-11-01T12:00:40+00:00</lastmod></url>' .
+					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-1</loc></url>' .
+					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-2</loc></url>' .
+					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-3</loc></url>' .
+					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-4</loc></url>' .
+					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-5</loc></url>' .
 					'</urlset>';
 
 		$this->assertXMLEquals( $expected, $actual, 'Sitemap page markup incorrect.' );
@@ -162,7 +151,6 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$url_list = array(
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-1',
-				'lastmod' => '2019-11-01T12:00:00+00:00',
 			),
 		);
 
@@ -187,13 +175,11 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$url_list = array(
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-1',
-				'lastmod' => '2019-11-01T12:00:00+00:00',
 				'string'  => 'value',
 				'number'  => 200,
 			),
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-2',
-				'lastmod' => '2019-11-01T12:00:00+00:00',
 				'string'  => 'another value',
 				'number'  => 300,
 			),

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -1,9 +1,12 @@
 <?php
 
+/**
+ * @group renderer
+ */
 class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 	public function test_get_sitemap_stylesheet_url() {
 		$sitemap_renderer = new Core_Sitemaps_Renderer();
-		$stylesheet_url = $sitemap_renderer->get_sitemap_stylesheet_url();
+		$stylesheet_url   = $sitemap_renderer->get_sitemap_stylesheet_url();
 
 		$this->assertStringEndsWith( '/?sitemap-stylesheet=xsl', $stylesheet_url );
 	}
@@ -13,7 +16,7 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$this->set_permalink_structure( '/%year%/%postname%/' );
 
 		$sitemap_renderer = new Core_Sitemaps_Renderer();
-		$stylesheet_url = $sitemap_renderer->get_sitemap_stylesheet_url();
+		$stylesheet_url   = $sitemap_renderer->get_sitemap_stylesheet_url();
 
 		// Clean up permalinks.
 		$this->set_permalink_structure();
@@ -23,7 +26,7 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 
 	public function test_get_sitemap_index_stylesheet_url() {
 		$sitemap_renderer = new Core_Sitemaps_Renderer();
-		$stylesheet_url = $sitemap_renderer->get_sitemap_index_stylesheet_url();
+		$stylesheet_url   = $sitemap_renderer->get_sitemap_index_stylesheet_url();
 
 		$this->assertStringEndsWith( '/?sitemap-stylesheet=index', $stylesheet_url );
 	}
@@ -33,7 +36,7 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$this->set_permalink_structure( '/%year%/%postname%/' );
 
 		$sitemap_renderer = new Core_Sitemaps_Renderer();
-		$stylesheet_url = $sitemap_renderer->get_sitemap_index_stylesheet_url();
+		$stylesheet_url   = $sitemap_renderer->get_sitemap_index_stylesheet_url();
 
 		// Clean up permalinks.
 		$this->set_permalink_structure();
@@ -70,19 +73,18 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 
 		$renderer = new Core_Sitemaps_Renderer();
 
-		$xml = $renderer->get_sitemap_index_xml( $entries );
-
-		$expected = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL .
-					'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/?sitemap-stylesheet=index" ?>' . PHP_EOL .
+		$actual   = $renderer->get_sitemap_index_xml( $entries );
+		$expected = '<?xml version="1.0" encoding="UTF-8"?>' .
+					'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/?sitemap-stylesheet=index" ?>' .
 					'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
 					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml</loc><lastmod>2019-11-01T12:00:00+00:00</lastmod></sitemap>' .
 					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-page-1.xml</loc><lastmod>2019-11-01T12:00:10+00:00</lastmod></sitemap>' .
 					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-category-1.xml</loc><lastmod>2019-11-01T12:00:20+00:00</lastmod></sitemap>' .
 					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-taxonomies-post_tag-1.xml</loc><lastmod>2019-11-01T12:00:30+00:00</lastmod></sitemap>' .
 					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-users-1.xml</loc><lastmod>2019-11-01T12:00:40+00:00</lastmod></sitemap>' .
-					'</sitemapindex>' . PHP_EOL;
+					'</sitemapindex>';
 
-		$this->assertSame( $expected, $xml, 'Sitemap index markup incorrect.' );
+		$this->assertXMLEquals( $expected, $actual, 'Sitemap index markup incorrect.' );
 	}
 
 	/**
@@ -114,19 +116,18 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 
 		$renderer = new Core_Sitemaps_Renderer();
 
-		$xml = $renderer->get_sitemap_xml( $url_list );
-
-		$expected = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL .
-					'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/?sitemap-stylesheet=xsl" ?>' . PHP_EOL .
+		$actual   = $renderer->get_sitemap_xml( $url_list );
+		$expected = '<?xml version="1.0" encoding="UTF-8"?>' .
+					'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/?sitemap-stylesheet=xsl" ?>' .
 					'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
 					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-1</loc><lastmod>2019-11-01T12:00:00+00:00</lastmod></url>' .
 					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-2</loc><lastmod>2019-11-01T12:00:10+00:00</lastmod></url>' .
 					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-3</loc><lastmod>2019-11-01T12:00:20+00:00</lastmod></url>' .
 					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-4</loc><lastmod>2019-11-01T12:00:30+00:00</lastmod></url>' .
 					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-5</loc><lastmod>2019-11-01T12:00:40+00:00</lastmod></url>' .
-					'</urlset>' . PHP_EOL;
+					'</urlset>';
 
-		$this->assertSame( $expected, $xml, 'Sitemap page markup incorrect.' );
+		$this->assertXMLEquals( $expected, $actual, 'Sitemap page markup incorrect.' );
 	}
 
 	/**
@@ -140,13 +141,128 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 				'string'  => 'value',
 				'number'  => 200,
 			),
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-2',
+				'lastmod' => '2019-11-01T12:00:00+00:00',
+				'string'  => 'another value',
+				'number'  => 300,
+			),
 		);
 
 		$renderer = new Core_Sitemaps_Renderer();
 
-		$xml = $renderer->get_sitemap_xml( $url_list );
+		$xmlDOM   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
+		$xpath    = new DOMXPath( $xmlDOM );
+		$xpath->registerNamespace( 'sitemap', 'http://www.sitemaps.org/schemas/sitemap/0.9' );
 
-		$this->assertContains( '<string>value</string>', $xml, 'Extra string attributes are not being rendered in XML.' );
-		$this->assertContains( '<number>200</number>', $xml, 'Extra number attributes are not being rendered in XML.' );
+		$this->assertEquals(
+			count( $url_list ),
+			$xpath->evaluate( 'count( /sitemap:urlset/sitemap:url/sitemap:string )' ),
+			'Extra string attributes are not being rendered in XML.'
+		);
+		$this->assertEquals(
+			count( $url_list ),
+			$xpath->evaluate( 'count( /sitemap:urlset/sitemap:url/sitemap:number )' ),
+			'Extra number attributes are not being rendered in XML.'
+		);
+
+		foreach ( $url_list as $idx => $url_item ) {
+			// XPath position() is 1-indexed, so incrememnt $idx accordingly.
+			$idx++;
+
+			$this->assertEquals(
+				$url_item['string'],
+				$xpath->evaluate( "string( /sitemap:urlset/sitemap:url[ {$idx} ]/sitemap:string )" ),
+				'Extra string attributes are not being rendered in XML.'
+			);
+			$this->assertEquals(
+				$url_item['number'],
+				$xpath->evaluate( "string( /sitemap:urlset//sitemap:url[ {$idx} ]/sitemap:number )" ),
+				'Extra number attributes are not being rendered in XML.'
+			);
+		}
+	}
+
+	/**
+	 * Load XML from a string.
+	 *
+	 * @param string $xml
+	 * @param int    $options Bitwise OR of the {@link https://www.php.net/manual/en/libxml.constants.php libxml option constants}.
+	 *                        Default is 0.
+	 * @return DOMDocument
+	 */
+	public function loadXML( $xml, $options = 0 ) {
+		// Suppress PHP warnings generated by DOMDocument::loadXML(), which would cause
+		// PHPUnit to incorrectly report an error instead of a just a failure.
+		$internal = libxml_use_internal_errors( true );
+		libxml_clear_errors();
+
+		$xmlDOM = new DOMDocument();
+
+		$this->assertTrue(
+			$xmlDOM->loadXML( $xml, $options ),
+			libxml_get_last_error() ? sprintf( 'Non-well-formed XML: %s.', libxml_get_last_error()->message ) : ''
+		);
+
+		// Restore default error handler.
+		libxml_use_internal_errors( $internal );
+		libxml_clear_errors();
+
+		return $xmlDOM;
+	}
+
+	/**
+	 * Normalize an XML document to make comparing two documents easier.
+	 *
+	 * @param string $xml
+	 * @param int    $options Bitwise OR of the {@link https://www.php.net/manual/en/libxml.constants.php libxml option constants}.
+	 *                        Default is 0.
+	 * @return string The normalized form of `$xml`.
+	 */
+	public function normalizeXML( $xml, $options = 0 ) {
+		static $xsltProc;
+
+		if ( ! $xsltProc ) {
+			$xsltProc = new XSLTProcessor();
+			$xsltProc->importStyleSheet( simplexml_load_file( WP_TESTS_ASSETS_DIR . '/normalize-xml.xsl' ) );
+		}
+
+		return $xsltProc->transformToXML( $this->loadXML( $xml, $options ) );
+	}
+
+	/**
+	 * Reports an error identified by `$message` if the namespace normalized form of the XML document in `$actualXml`
+	 * is equal to the namespace normalized form of the XML document in `$expectedXml`.
+	 *
+	 * This is similar to {@link https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertXmlStringEqualsXmlString assertXmlStringEqualsXmlString()}
+	 * except that differences in namespace prefixes are normalized away, such that given
+	 * `$actualXml = "<root xmlns='urn:wordpress.org'><child/></root>";` and
+	 * `$expectedXml = "<ns0:root xmlns:ns0='urn:wordpress.org'><ns0:child></ns0:root>";`
+	 * then `$this->assertXMLEquals( $expectedXml, $actualXml )` will succeed.
+	 *
+	 * @param string $expectedXml
+	 * @param string $actualXml
+	 * @param string $message   Optional. Message to display when the assertion fails.
+	 */
+	public function assertXMLEquals( $expectedXml, $actualXml, $message = '' ) {
+		$this->assertEquals( $this->normalizeXML( $expectedXml ), $this->normalizeXML( $actualXml ), $message );
+	}
+
+	/**
+	 * Reports an error identified by `$message` if the namespace normalized form of the XML document in `$actualXml`
+	 * is not equal to the namespace normalized form of the XML document in `$expectedXml`.
+	 *
+	 * This is similar to {@link https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertXmlStringEqualsXmlString assertXmlStringNotEqualsXmlString()}
+	 * except that differences in namespace prefixes are normalized away, such that given
+	 * `$actualXml = "<root xmlns='urn:wordpress.org'><child></root>";` and
+	 * `$expectedXml = "<ns0:root xmlns:ns0='urn:wordpress.org'><ns0:child/></ns0:root>";`
+	 * then `$this->assertXMLNotEquals( $expectedXml, $actualXml )` will fail.
+	 *
+	 * @param string $expectedXml
+	 * @param string $actualXml
+	 * @param string $message   Optional. Message to display when the assertion fails.
+	 */
+	public function assertXMLNotEquals( $expectedXml, $actualXml, $message = '' ) {
+		$this->assertNotEquals( $this->normalizeXML( $expectedXml ), $this->normalizeXML( $actualXml ), $message );
 	}
 }

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -270,14 +270,14 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 	 * @return string The normalized form of `$xml`.
 	 */
 	public function normalizeXML( $xml, $options = 0 ) {
-		static $xsltProc;
+		static $xslt_proc;
 
-		if ( ! $xsltProc ) {
-			$xsltProc = new XSLTProcessor();
-			$xsltProc->importStyleSheet( simplexml_load_file( WP_TESTS_ASSETS_DIR . '/normalize-xml.xsl' ) );
+		if ( ! $xslt_proc ) {
+			$xslt_proc = new XSLTProcessor();
+			$xslt_proc->importStyleSheet( simplexml_load_file( WP_TESTS_ASSETS_DIR . '/normalize-xml.xsl' ) );
 		}
 
-		return $xsltProc->transformToXML( $this->loadXML( $xml, $options ) );
+		return $xslt_proc->transformToXML( $this->loadXML( $xml, $options ) );
 	}
 
 	/**
@@ -294,8 +294,8 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 	 * @param string $actualXml
 	 * @param string $message   Optional. Message to display when the assertion fails.
 	 */
-	public function assertXMLEquals( $expectedXml, $actualXml, $message = '' ) {
-		$this->assertEquals( $this->normalizeXML( $expectedXml ), $this->normalizeXML( $actualXml ), $message );
+	public function assertXMLEquals( $expectedXml, $actualXml, $message = '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$this->assertEquals( $this->normalizeXML( $expectedXml ), $this->normalizeXML( $actualXml ), $message ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	}
 
 	/**
@@ -312,7 +312,7 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 	 * @param string $actualXml
 	 * @param string $message   Optional. Message to display when the assertion fails.
 	 */
-	public function assertXMLNotEquals( $expectedXml, $actualXml, $message = '' ) {
-		$this->assertNotEquals( $this->normalizeXML( $expectedXml ), $this->normalizeXML( $actualXml ), $message );
+	public function assertXMLNotEquals( $expectedXml, $actualXml, $message = '' ) { //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$this->assertNotEquals( $this->normalizeXML( $expectedXml ), $this->normalizeXML( $actualXml ), $message ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	}
 }

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -105,10 +105,10 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$xml_dom   = $this->loadXML( $renderer->get_sitemap_index_xml( $entries ) );
 		$xpath    = new DOMXPath( $xml_dom );
 
-		$this->assertCount(
+		$this->assertSame(
 			0,
-			$xpath->query( '//processing-instruction( "xml-stylesheet" )' ),
-			'Sitemap incorrectly contains the xml-stylesheet processing instruction.'
+			$xpath->query( '//processing-instruction( "xml-stylesheet" )' )->length,
+			'Sitemap index incorrectly contains the xml-stylesheet processing instruction.'
 		);
 	}
 
@@ -173,9 +173,9 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$xml_dom   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
 		$xpath    = new DOMXPath( $xml_dom );
 
-		$this->assertCount(
+		$this->assertSame(
 			0,
-			$xpath->query( '//processing-instruction( "xml-stylesheet" )' ),
+			$xpath->query( '//processing-instruction( "xml-stylesheet" )' )->length,
 			'Sitemap incorrectly contains the xml-stylesheet processing instruction.'
 		);
 	}

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -102,8 +102,8 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 
 		$renderer = new Core_Sitemaps_Renderer();
 
-		$xmlDOM   = $this->loadXML( $renderer->get_sitemap_index_xml( $entries ) );
-		$xpath    = new DOMXPath( $xmlDOM );
+		$xmlDom   = $this->loadXML( $renderer->get_sitemap_index_xml( $entries ) );
+		$xpath    = new DOMXPath( $xmlDom );
 
 		$this->assertCount(
 			0,
@@ -170,8 +170,8 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 
 		$renderer = new Core_Sitemaps_Renderer();
 
-		$xmlDOM   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
-		$xpath    = new DOMXPath( $xmlDOM );
+		$xmlDom   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
+		$xpath    = new DOMXPath( $xmlDom );
 
 		$this->assertCount(
 			0,
@@ -201,8 +201,8 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 
 		$renderer = new Core_Sitemaps_Renderer();
 
-		$xmlDOM   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
-		$xpath    = new DOMXPath( $xmlDOM );
+		$xmlDom   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
+		$xpath    = new DOMXPath( $xmlDom );
 		$xpath->registerNamespace( 'sitemap', 'http://www.sitemaps.org/schemas/sitemap/0.9' );
 
 		$this->assertEquals(
@@ -247,10 +247,10 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		$internal = libxml_use_internal_errors( true );
 		libxml_clear_errors();
 
-		$xmlDOM = new DOMDocument();
+		$xmlDom = new DOMDocument();
 
 		$this->assertTrue(
-			$xmlDOM->loadXML( $xml, $options ),
+			$xmlDom->loadXML( $xml, $options ),
 			libxml_get_last_error() ? sprintf( 'Non-well-formed XML: %s.', libxml_get_last_error()->message ) : ''
 		);
 
@@ -258,7 +258,7 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 		libxml_use_internal_errors( $internal );
 		libxml_clear_errors();
 
-		return $xmlDOM;
+		return $xmlDom;
 	}
 
 	/**

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -88,6 +88,33 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test XML output for the sitemap index renderer when stylesheet is disabled.
+	 */
+	public function test_get_sitemap_index_xml_without_stylsheet() {
+		$entries = array(
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml',
+				'lastmod' => '2019-11-01T12:00:00+00:00',
+			),
+		);
+
+		add_filter( 'core_sitemaps_stylesheet_index_url', '__return_false' );
+
+		$renderer = new Core_Sitemaps_Renderer();
+
+		$xmlDOM   = $this->loadXML( $renderer->get_sitemap_index_xml( $entries ) );
+		$xpath    = new DOMXPath( $xmlDOM );
+
+		$this->assertCount(
+			0,
+			$xpath->query( '//processing-instruction( "xml-stylesheet" )' ),
+			'Sitemap incorrectly contains the xml-stylesheet processing instruction.'
+		);
+
+		return;
+	}
+
+	/**
 	 * Test XML output for the sitemap page renderer.
 	 */
 	public function test_get_sitemap_xml() {
@@ -128,6 +155,33 @@ class Test_Core_Sitemaps_Renderer extends WP_UnitTestCase {
 					'</urlset>';
 
 		$this->assertXMLEquals( $expected, $actual, 'Sitemap page markup incorrect.' );
+	}
+
+	/**
+	 * Test XML output for the sitemap page renderer when stylesheet is disabled.
+	 */
+	public function test_get_sitemap_xml_without_stylsheet() {
+		$url_list = array(
+			array(
+				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-1',
+				'lastmod' => '2019-11-01T12:00:00+00:00',
+			),
+		);
+
+		add_filter( 'core_sitemaps_stylesheet_url', '__return_false' );
+
+		$renderer = new Core_Sitemaps_Renderer();
+
+		$xmlDOM   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
+		$xpath    = new DOMXPath( $xmlDOM );
+
+		$this->assertCount(
+			0,
+			$xpath->query( '//processing-instruction( "xml-stylesheet" )' ),
+			'Sitemap incorrectly contains the xml-stylesheet processing instruction.'
+		);
+
+		return;
 	}
 
 	/**

--- a/tests/wp-tests-config.php
+++ b/tests/wp-tests-config.php
@@ -32,3 +32,4 @@ define( 'WP_TESTS_DOMAIN', 'localhost:8000' );
 define( 'WP_TESTS_EMAIL', 'admin@example.org' );
 define( 'WP_TESTS_TITLE', 'HM Tests' );
 define( 'WP_PHP_BINARY', 'php' );
+define( 'WP_TESTS_ASSETS_DIR', __DIR__ . '/assets' );


### PR DESCRIPTION
### Issue Number
Fixes #156.

### Description
Improves the unit tests for `Core_Sitemaps_Renderer` by making them more "xml-aware".

Adds the following methods to `Test_Core_Sitemaps_Renderer`:

* loadXML()
    * this is a simple wrapper around `DOMDocument::loadXML()` which can be used to assert that a string is well-formed XML
* normalizeXML()
    * normalizes an XML document to make it easier to compare against another XML document.  Among the normalizations are: 1) convert to UTF-8 (if not already in UTF-8), 2) strip insignificant whitespace, 3) convert CDATA sections and character references (named and numeric) to their string values; 4) order attributes by their namespace-uri() then their local-name(); 5) (most importantly) normalize the namespace prefixes used.  For example, `<root xmlns='urn:wordpress.org'><child foo='bar' bar='foo'>this is &quot;a test&quot;</child></root>` and `<ns0:root xmlns:ns0='urn:wordpress.org'><ns1:child xmlns:ns1='urn:wordpress.org' bar='foo' foo='bar'><![CDATA[this is "a test"]]></ns1:child></ns0:root>` will both normalize such that `assertEquals()` will succeed
* assertXMLEquals()
    * similar in spirit to PHPUnits `assertXmlStringEqualsXmlString()` but uses the new `normalizeXML()` method to ensure that insignificant differences that cause `assertXmlStringEqualsXmlString()` to fail will still succeed
* assertXMLNotEquals()
    * similar in spirit to PHPUnits `assertXmlStringNotEqualsXmlString()` but uses the new `normalizeXML()` method to ensure that insignificant differences that cause `assertXmlStringNotEqualsXmlString()` to succeed will still fail

It is my intention that when this feature plugin gets merged into core that these methods will be added to `WP_UnitTestCase`.  The documentation on `normalizeXML()` and the XSLT transform it uses will surely need to be improved when that happens, but I think it is good enough for now.

Existing unit tests have been rewritten to use the above new methods and/or `DOMXPath::evaluate()` expressions.

Also adds 2 new unit tests for the `core_sitemaps_stylesheet_url` and `core_sitemaps_stylesheet_index_url` filters; as well as a few WPCS fixes.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have added test instructions that prove my fix is effective or that my feature works.
