### PR TITLE
Prevent trailing slashes redirect for stylesheet.

### DIFF
--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -38,7 +38,7 @@ class Core_Sitemaps_Index {
 	 * @return bool|string $redirect
 	 */
 	public function redirect_canonical( $redirect ) {
-		if ( get_query_var( 'sitemap' ) ) {
+		if ( get_query_var( 'sitemap' ) || get_query_var( 'sitemap-stylesheet' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Issue Number
#159.

### Description

Adds `get_query_var( 'sitemap-stylesheet' )` to the conditional for returning false in `Core_Sitemaps_Index::redirect_canonical()`.

### Screenshots (before and after if applicable)

![stylesheet-redirect](https://user-images.githubusercontent.com/3824560/80019880-70760e00-8495-11ea-9549-a2b296ae6535.png)

### Type of change
Please select the relevant options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test

$ head https://example.com/wp-sitemap.xsl

See that there is no longer a redirect to the canonical (trailing slash) URL

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [X] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have added test instructions that prove my fix is effective or that my feature works.
