### PR TITLE
Rewrites: add _ (underscore) to the sub-type clause of the rewrites regex, so that the built-in post_tag taxonomy is matched.

### DIFF
--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -112,7 +112,7 @@ class Core_Sitemaps {
 
 		// Register routes for providers.
 		add_rewrite_rule(
-			'^wp-sitemap-([a-z]+?)-([a-z\d-]+?)-(\d+?)\.xml$',
+			'^wp-sitemap-([a-z]+?)-([a-z\d_-]+?)-(\d+?)\.xml$',
 			'index.php?sitemap=$matches[1]&sitemap-sub-type=$matches[2]&paged=$matches[3]',
 			'top'
 		);


### PR DESCRIPTION
### Issue Number

Fixes #167 

### Description

Adds `_` (underscore) to the character class in the `sub-type` clause of the rewrites regex, so that the built-in `post_tag` taxonomy is matched.

### Type of change
Please select the relevant options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test

1. assign any tag to a public post
2. see that `https://example.com/wp-sitemaps-taxonomies-post_tag-1.xml` correctly resolves (with HTTP status 200 and not 404)

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [] My changes generate no new warnings.
- [X] I have added test instructions that prove my fix is effective or that my feature works.
