### PR TITLE
Make registry API methods consistent in naming

### DIFF
--- a/inc/class-core-sitemaps-registry.php
+++ b/inc/class-core-sitemaps-registry.php
@@ -48,7 +48,7 @@ class Core_Sitemaps_Registry {
 	}
 
 	/**
-	 * Returns a single registered sitemaps.
+	 * Returns a single registered sitemaps provider.
 	 *
 	 * @since 5.5.0
 	 *

--- a/inc/class-core-sitemaps-registry.php
+++ b/inc/class-core-sitemaps-registry.php
@@ -42,13 +42,13 @@ class Core_Sitemaps_Registry {
 	}
 
 	/**
-	 * Returns a single sitemap provider.
+	 * Returns a single registered sitemaps.
 	 *
 	 * @param string $name Sitemap provider name.
 	 *
-	 * @return Core_Sitemaps_Provider|null Provider if it exists, null otherwise.
+	 * @return Core_Sitemaps_Provider|null Sitemap provider if it exists, null otherwise.
 	 */
-	public function get_provider( $name ) {
+	public function get_sitemap( $name ) {
 		if ( ! isset( $this->sitemaps[ $name ] ) ) {
 			return null;
 		}

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -190,7 +190,7 @@ class Core_Sitemaps {
 			exit;
 		}
 
-		$provider = $this->registry->get_provider( $sitemap );
+		$provider = $this->registry->get_sitemap( $sitemap );
 
 		if ( ! $provider ) {
 			return;


### PR DESCRIPTION
### Description
Currently the API exposed by `Core_Sitemaps_Registry` is inconsistent:
* `add_sitemap`
* `get_provider`
* `get_sitemaps`

In all cases, it's about registering or getting registered sitemap provider objects, so these names should reflect that. In this PR I'm opting for renaming `get_provider` to `get_sitemap` because I think the "provider" name is more technical and is explained when it comes to method parameters and return values anyway. I'm not opposed to naming everything "provider"-based instead if there's a good reason for that - the main takeaway is that these should be consistently named.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
