### PR TITLE
More consistent naming, docs and behavior around object types and subtypes

### DIFF
--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -148,6 +148,20 @@ abstract class Core_Sitemaps_Provider {
 		/* @var WP_Rewrite $wp_rewrite */
 		global $wp_rewrite;
 
+		if ( ! $wp_rewrite->using_permalinks() ) {
+			return add_query_arg(
+				// Accounts for cases where name is not included, ex: sitemaps-users-1.xml.
+				array_filter(
+					array(
+						'sitemap'          => $this->object_type,
+						'sitemap-sub-type' => $name,
+						'paged'            => $page,
+					)
+				),
+				home_url( '/' )
+			);
+		}
+
 		$basename = sprintf(
 			'/wp-sitemap-%1$s.xml',
 			implode(
@@ -163,23 +177,7 @@ abstract class Core_Sitemaps_Provider {
 			)
 		);
 
-		$url = home_url( $basename );
-
-		if ( ! $wp_rewrite->using_permalinks() ) {
-			$url = add_query_arg(
-				// Accounts for cases where name is not included, ex: sitemaps-users-1.xml.
-				array_filter(
-					array(
-						'sitemap'          => $this->object_type,
-						'sitemap-sub-type' => $name,
-						'paged'            => $page,
-					)
-				),
-				home_url( '/' )
-			);
-		}
-
-		return $url;
+		return home_url( $basename );
 	}
 
 	/**

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -206,9 +206,9 @@ abstract class Core_Sitemaps_Provider {
 		}
 
 		/**
-		 * To prevent complexity in code calling this function, such as `get_sitemaps()` in this class,
-		 * an iterable type is returned. The value false was chosen as it passes empty() checks and
-		 * as semantically this provider does not provide sub-types.
+		 * To prevent complexity in code calling this function, such as `get_sitemap_type_data()`
+		 * in this class, a non-empty array is returned, so that sitemaps for providers without
+		 * object subtypes are still registered correctly.
 		 *
 		 * @link https://github.com/GoogleChromeLabs/wp-sitemaps/pull/72#discussion_r347496750
 		 */

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -17,6 +17,17 @@
 abstract class Core_Sitemaps_Provider {
 
 	/**
+	 * Provider name.
+	 *
+	 * This will also be used as the public-facing name in URLs.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @var string
+	 */
+	protected $name = '';
+
+	/**
 	 * Object type name (e.g. 'post', 'term', 'user').
 	 *
 	 * @since 5.5.0
@@ -153,7 +164,7 @@ abstract class Core_Sitemaps_Provider {
 				// Accounts for cases where name is not included, ex: sitemaps-users-1.xml.
 				array_filter(
 					array(
-						'sitemap'          => $this->object_type,
+						'sitemap'          => $this->name,
 						'sitemap-sub-type' => $name,
 						'paged'            => $page,
 					)
@@ -169,7 +180,7 @@ abstract class Core_Sitemaps_Provider {
 				// Accounts for cases where name is not included, ex: sitemaps-users-1.xml.
 				array_filter(
 					array(
-						$this->object_type,
+						$this->name,
 						$name,
 						(string) $page,
 					)

--- a/inc/class-core-sitemaps-provider.php
+++ b/inc/class-core-sitemaps-provider.php
@@ -15,8 +15,9 @@
  * @since 5.5.0
  */
 class Core_Sitemaps_Provider {
+
 	/**
-	 * Post type name.
+	 * Object type name (e.g. 'post', 'term', 'user').
 	 *
 	 * @since 5.5.0
 	 *
@@ -25,42 +26,43 @@ class Core_Sitemaps_Provider {
 	protected $object_type = '';
 
 	/**
-	 * Sub type name.
+	 * Object subtype name.
+	 *
+	 * For example, this should be a post type name for object type 'post' or
+	 * a taxonomy name for object type 'term').
 	 *
 	 * @since 5.5.0
 	 *
 	 * @var string
 	 */
-	protected $sub_type = '';
+	protected $object_subtype = '';
 
 	/**
 	 * Gets a URL list for a sitemap.
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param int    $page_num Page of results.
-	 * @param string $type     Optional. Post type name. Default ''.
+	 * @param int    $page_num       Page of results.
+	 * @param string $object_subtype Optional. Object subtype name. Default empty.
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num, $type = '' ) {
+	public function get_url_list( $page_num, $object_subtype = '' ) {
 		return array();
 	}
 
 	/**
-	 * Returns the name of the object type being queried.
+	 * Returns the name of the object type or object subtype being queried.
 	 *
 	 * @since 5.5.0
 	 *
-	 * @return string Name of the object type.
+	 * @return string Object subtype if set, otherwise object type.
 	 */
 	public function get_queried_type() {
-		$type = $this->sub_type;
-
-		if ( empty( $type ) ) {
+		if ( empty( $this->object_subtype ) ) {
 			return $this->object_type;
 		}
 
-		return $type;
+		return $this->object_subtype;
 	}
 
 	/**
@@ -68,12 +70,12 @@ class Core_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param string $type Optional. Object type. Default is null.
+	 * @param string $object_subtype Optional. Object subtype. Default empty.
 	 * @return int Total number of pages.
 	 */
-	public function max_num_pages( $type = '' ) {
-		if ( empty( $type ) ) {
-			$type = $this->get_queried_type();
+	public function max_num_pages( $object_subtype = '' ) {
+		if ( empty( $object_subtype ) ) {
+			$object_subtype = $this->get_queried_type();
 		}
 
 		$query = new WP_Query(
@@ -81,7 +83,7 @@ class Core_Sitemaps_Provider {
 				'fields'                 => 'ids',
 				'orderby'                => 'ID',
 				'order'                  => 'ASC',
-				'post_type'              => $type,
+				'post_type'              => $object_subtype,
 				'posts_per_page'         => core_sitemaps_get_max_urls( $this->object_type ),
 				'paged'                  => 1,
 				'update_post_term_cache' => false,
@@ -93,15 +95,15 @@ class Core_Sitemaps_Provider {
 	}
 
 	/**
-	 * Sets the object sub_type.
+	 * Sets the object subtype.
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param string $sub_type The name of the object subtype.
+	 * @param string $object_subtype The name of the object subtype.
 	 * @return bool Returns true on success.
 	 */
-	public function set_sub_type( $sub_type ) {
-		$this->sub_type = $sub_type;
+	public function set_object_subtype( $object_subtype ) {
+		$this->object_subtype = $object_subtype;
 
 		return true;
 	}
@@ -116,17 +118,17 @@ class Core_Sitemaps_Provider {
 	public function get_sitemap_type_data() {
 		$sitemap_data = array();
 
-		$sitemap_types = $this->get_object_sub_types();
+		$object_subtypes = $this->get_object_subtypes();
 
-		foreach ( $sitemap_types as $type ) {
+		foreach ( $object_subtypes as $object_subtype ) {
 			// Handle lists of post-objects.
-			if ( isset( $type->name ) ) {
-				$type = $type->name;
+			if ( isset( $object_subtype->name ) ) {
+				$object_subtype = $object_subtype->name;
 			}
 
 			$sitemap_data[] = array(
-				'name'   => $type,
-				'pages' => $this->max_num_pages( $type ),
+				'name'   => $object_subtype,
+				'pages' => $this->max_num_pages( $object_subtype ),
 			);
 		}
 
@@ -197,15 +199,15 @@ class Core_Sitemaps_Provider {
 	/**
 	 * Returns the list of supported object sub-types exposed by the provider.
 	 *
-	 * By default this is the sub_type as specified in the class property.
+	 * By default this is the subtype as specified in the class property.
 	 *
 	 * @since 5.5.0
 	 *
 	 * @return array List: containing object types or false if there are no subtypes.
 	 */
-	public function get_object_sub_types() {
-		if ( ! empty( $this->sub_type ) ) {
-			return array( $this->sub_type );
+	public function get_object_subtypes() {
+		if ( ! empty( $this->object_subtype ) ) {
+			return array( $this->object_subtype );
 		}
 
 		/**

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -211,7 +211,7 @@ class Core_Sitemaps {
 
 		// Only set the current object sub-type if it's supported.
 		if ( isset( $object_subtypes[ $object_subtype ] ) ) {
-			$provider->set_object_subtype( $object_subtypes[ $object_subtype ]->name );
+			$provider->set_object_subtype( $object_subtype );
 		}
 
 		$url_list = $provider->get_url_list( $paged, $object_subtype );

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -80,9 +80,9 @@ class Core_Sitemaps {
 		/**
 		 * Filters the list of registered sitemap providers.
 		 *
-		 * @since 0.1.0
+		 * @since 5.5.0
 		 *
-		 * @param array $providers Array of Core_Sitemap_Provider objects.
+		 * @param array $providers Array of Core_Sitemap_Provider objects keyed by their name.
 		 */
 		$providers = apply_filters(
 			'core_sitemaps_register_providers',

--- a/inc/class-core-sitemaps.php
+++ b/inc/class-core-sitemaps.php
@@ -172,7 +172,7 @@ class Core_Sitemaps {
 		global $wp_query;
 
 		$sitemap         = sanitize_text_field( get_query_var( 'sitemap' ) );
-		$sub_type        = sanitize_text_field( get_query_var( 'sitemap-sub-type' ) );
+		$object_subtype  = sanitize_text_field( get_query_var( 'sitemap-sub-type' ) );
 		$stylesheet_type = sanitize_text_field( get_query_var( 'sitemap-stylesheet' ) );
 		$paged           = absint( get_query_var( 'paged' ) );
 
@@ -207,14 +207,14 @@ class Core_Sitemaps {
 			$paged = 1;
 		}
 
-		$sub_types = $provider->get_object_sub_types();
+		$object_subtypes = $provider->get_object_subtypes();
 
 		// Only set the current object sub-type if it's supported.
-		if ( isset( $sub_types[ $sub_type ] ) ) {
-			$provider->set_sub_type( $sub_types[ $sub_type ]->name );
+		if ( isset( $object_subtypes[ $object_subtype ] ) ) {
+			$provider->set_object_subtype( $object_subtypes[ $object_subtype ]->name );
 		}
 
-		$url_list = $provider->get_url_list( $paged, $sub_type );
+		$url_list = $provider->get_url_list( $paged, $object_subtype );
 
 		// Force a 404 and bail early if no URLs are present.
 		if ( empty( $url_list ) ) {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -103,18 +103,17 @@ function core_sitemaps_register_sitemap( $name, $provider ) {
  *
  * @since 5.5.0
  *
- * @param string $type Optional. The type of sitemap to be filtered. Default empty.
+ * @param string $object_type Object type for sitemap to be filtered (e.g. 'post', 'term', 'user').
  * @return int The maximum number of URLs.
  */
-function core_sitemaps_get_max_urls( $type = '' ) {
+function core_sitemaps_get_max_urls( $object_type ) {
 	/**
 	 * Filters the maximum number of URLs displayed on a sitemap.
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param int    $max_urls The maximum number of URLs included in a sitemap. Default 2000.
-	 * @param string $type     Optional. The type of sitemap to be filtered. Default empty.
-	 * @return int The maximum number of URLs.
+	 * @param int    $max_urls    The maximum number of URLs included in a sitemap. Default 2000.
+	 * @param string $object_type Object type for sitemap to be filtered (e.g. 'post', 'term', 'user').
 	 */
-	return apply_filters( 'core_sitemaps_max_urls', CORE_SITEMAPS_MAX_URLS, $type );
+	return apply_filters( 'core_sitemaps_max_urls', CORE_SITEMAPS_MAX_URLS, $object_type );
 }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -103,7 +103,7 @@ function core_sitemaps_register_sitemap( $name, $provider ) {
  *
  * @since 5.5.0
  *
- * @param string $type Optional. The type of sitemap to be filtered. Default ''.
+ * @param string $type Optional. The type of sitemap to be filtered. Default empty.
  * @return int The maximum number of URLs.
  */
 function core_sitemaps_get_max_urls( $type = '' ) {
@@ -113,7 +113,7 @@ function core_sitemaps_get_max_urls( $type = '' ) {
 	 * @since 5.5.0
 	 *
 	 * @param int    $max_urls The maximum number of URLs included in a sitemap. Default 2000.
-	 * @param string $type     Optional. The type of sitemap to be filtered. Default ''.
+	 * @param string $type     Optional. The type of sitemap to be filtered. Default empty.
 	 * @return int The maximum number of URLs.
 	 */
 	return apply_filters( 'core_sitemaps_max_urls', CORE_SITEMAPS_MAX_URLS, $type );

--- a/inc/providers/class-core-sitemaps-posts.php
+++ b/inc/providers/class-core-sitemaps-posts.php
@@ -21,7 +21,8 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	 * @since 5.5.0
 	 */
 	public function __construct() {
-		$this->object_type = 'posts';
+		$this->name        = 'posts';
+		$this->object_type = 'post';
 	}
 
 	/**

--- a/inc/providers/class-core-sitemaps-posts.php
+++ b/inc/providers/class-core-sitemaps-posts.php
@@ -32,7 +32,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	 *
 	 * @return array $post_types List of registered object sub types.
 	 */
-	public function get_object_sub_types() {
+	public function get_object_subtypes() {
 		$post_types = get_post_types( array( 'public' => true ), 'objects' );
 		unset( $post_types['attachment'] );
 
@@ -51,19 +51,19 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param int    $page_num Page of results.
-	 * @param string $type     Optional. Post type name. Default ''.
+	 * @param int    $page_num  Page of results.
+	 * @param string $post_type Optional. Post type name. Default empty.
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num, $type = '' ) {
-		if ( ! $type ) {
-			$type = $this->get_queried_type();
+	public function get_url_list( $page_num, $post_type = '' ) {
+		if ( ! $post_type ) {
+			$post_type = $this->get_queried_type();
 		}
 
 		// Return an empty array if the type is not supported.
-		$supported_types = $this->get_object_sub_types();
+		$supported_types = $this->get_object_subtypes();
 
-		if ( ! isset( $supported_types[ $type ] ) ) {
+		if ( ! isset( $supported_types[ $post_type ] ) ) {
 			return array();
 		}
 
@@ -71,7 +71,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 			array(
 				'orderby'                => 'ID',
 				'order'                  => 'ASC',
-				'post_type'              => $type,
+				'post_type'              => $post_type,
 				'posts_per_page'         => core_sitemaps_get_max_urls( $this->object_type ),
 				'post_status'            => array( 'publish' ),
 				'paged'                  => $page_num,
@@ -94,7 +94,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 		 * Add a URL for the homepage in the pages sitemap.
 		 * Shows only on the first page if the reading settings are set to display latest posts.
 		 */
-		if ( 'page' === $type && 1 === $page_num && 'posts' === get_option( 'show_on_front' ) ) {
+		if ( 'page' === $post_type && 1 === $page_num && 'posts' === get_option( 'show_on_front' ) ) {
 			// Extract the data needed for home URL to add to the array.
 			$url_list[] = array(
 				'loc' => home_url(),
@@ -112,10 +112,10 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 		 *
 		 * @since 5.5.0
 		 *
-		 * @param array  $url_list List of URLs for a sitemap.
-		 * @param string $type     Name of the post_type.
-		 * @param int    $page_num Page number of the results.
+		 * @param array  $url_list  List of URLs for a sitemap.
+		 * @param string $post_type Name of the post_type.
+		 * @param int    $page_num  Page number of the results.
 		 */
-		return apply_filters( 'core_sitemaps_posts_url_list', $url_list, $type, $page_num );
+		return apply_filters( 'core_sitemaps_posts_url_list', $url_list, $post_type, $page_num );
 	}
 }

--- a/inc/providers/class-core-sitemaps-posts.php
+++ b/inc/providers/class-core-sitemaps-posts.php
@@ -30,7 +30,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @return array $post_types List of registered object sub types.
+	 * @return array Map of registered post type objects keyed by their name.
 	 */
 	public function get_object_subtypes() {
 		$post_types = get_post_types( array( 'public' => true ), 'objects' );
@@ -41,7 +41,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 		 *
 		 * @since 5.5.0
 		 *
-		 * @param array $post_types List of registered object sub types.
+		 * @param array $post_types Map of registered post type objects keyed by their name.
 		 */
 		return apply_filters( 'core_sitemaps_post_types', $post_types );
 	}
@@ -53,7 +53,7 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 	 *
 	 * @param int    $page_num  Page of results.
 	 * @param string $post_type Optional. Post type name. Default empty.
-	 * @return array $url_list List of URLs for a sitemap.
+	 * @return array List of URLs for a sitemap.
 	 */
 	public function get_url_list( $page_num, $post_type = '' ) {
 		if ( ! $post_type ) {
@@ -117,5 +117,34 @@ class Core_Sitemaps_Posts extends Core_Sitemaps_Provider {
 		 * @param int    $page_num  Page number of the results.
 		 */
 		return apply_filters( 'core_sitemaps_posts_url_list', $url_list, $post_type, $page_num );
+	}
+
+	/**
+	 * Gets the max number of pages available for the object type.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @param string $post_type Optional. Post type name. Default empty.
+	 * @return int Total number of pages.
+	 */
+	public function max_num_pages( $post_type = '' ) {
+		if ( empty( $post_type ) ) {
+			$post_type = $this->get_queried_type();
+		}
+
+		$query = new WP_Query(
+			array(
+				'fields'                 => 'ids',
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+				'post_type'              => $post_type,
+				'posts_per_page'         => core_sitemaps_get_max_urls( $this->object_type ),
+				'paged'                  => 1,
+				'update_post_term_cache' => false,
+				'update_post_meta_cache' => false,
+			)
+		);
+
+		return isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
 	}
 }

--- a/inc/providers/class-core-sitemaps-taxonomies.php
+++ b/inc/providers/class-core-sitemaps-taxonomies.php
@@ -30,24 +30,24 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 * @since 5.5.0
 	 *
 	 * @param int    $page_num Page of results.
-	 * @param string $type     Optional. Taxonomy type name. Default ''.
+	 * @param string $taxonomy Optional. Taxonomy name. Default empty.
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num, $type = '' ) {
-		// Find the query_var for sub_type.
-		if ( ! $type ) {
-			$type = $this->get_queried_type();
+	public function get_url_list( $page_num, $taxonomy = '' ) {
+		// Find the query_var for subtype.
+		if ( ! $taxonomy ) {
+			$taxonomy = $this->get_queried_type();
 		}
 
-		// Bail early if we don't have a taxonomy type.
-		if ( empty( $type ) ) {
+		// Bail early if we don't have a taxonomy.
+		if ( empty( $taxonomy ) ) {
 			return array();
 		}
 
-		$supported_types = $this->get_object_sub_types();
+		$supported_types = $this->get_object_subtypes();
 
 		// Bail early if the queried taxonomy is not a supported type.
-		if ( ! isset( $supported_types[ $type ] ) ) {
+		if ( ! isset( $supported_types[ $taxonomy ] ) ) {
 			return array();
 		}
 
@@ -58,7 +58,7 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 
 		$args = array(
 			'fields'                 => 'ids',
-			'taxonomy'               => $type,
+			'taxonomy'               => $taxonomy,
 			'orderby'                => 'term_order',
 			'number'                 => core_sitemaps_get_max_urls( $this->object_type ),
 			'offset'                 => $offset,
@@ -89,10 +89,10 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		 * @since 5.5.0
 		 *
 		 * @param array  $url_list List of URLs for a sitemap.
-		 * @param string $type     Name of the taxonomy_type.
+		 * @param string $taxonomy Taxonomy name.
 		 * @param int    $page_num Page of results.
 		 */
-		return apply_filters( 'core_sitemaps_taxonomies_url_list', $url_list, $type, $page_num );
+		return apply_filters( 'core_sitemaps_taxonomies_url_list', $url_list, $taxonomy, $page_num );
 	}
 
 	/**
@@ -100,17 +100,17 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 */
-	public function get_object_sub_types() {
-		$taxonomy_types = get_taxonomies( array( 'public' => true ), 'objects' );
+	public function get_object_subtypes() {
+		$taxonomies = get_taxonomies( array( 'public' => true ), 'objects' );
 
 		/**
-		 * Filter the list of taxonomy object sub types available within the sitemap.
+		 * Filter the list of taxonomy object subtypes available within the sitemap.
 		 *
 		 * @since 5.5.0
 		 *
-		 * @param array $taxonomy_types List of registered taxonomy type names.
+		 * @param array $taxonomies List of registered taxonomy names.
 		 */
-		return apply_filters( 'core_sitemaps_taxonomies', $taxonomy_types );
+		return apply_filters( 'core_sitemaps_taxonomies', $taxonomies );
 	}
 
 	/**
@@ -118,15 +118,15 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param string $type Taxonomy name.
+	 * @param string $taxonomy Taxonomy name.
 	 * @return int Total number of pages.
 	 */
-	public function max_num_pages( $type = '' ) {
-		if ( empty( $type ) ) {
-			$type = $this->get_queried_type();
+	public function max_num_pages( $taxonomy = '' ) {
+		if ( empty( $taxonomy ) ) {
+			$taxonomy = $this->get_queried_type();
 		}
 
-		$term_count = wp_count_terms( $type, array( 'hide_empty' => true ) );
+		$term_count = wp_count_terms( $taxonomy, array( 'hide_empty' => true ) );
 
 		return (int) ceil( $term_count / core_sitemaps_get_max_urls( $this->object_type ) );
 	}

--- a/inc/providers/class-core-sitemaps-taxonomies.php
+++ b/inc/providers/class-core-sitemaps-taxonomies.php
@@ -21,7 +21,8 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	 * @since 5.5.0
 	 */
 	public function __construct() {
-		$this->object_type = 'taxonomies';
+		$this->name        = 'taxonomies';
+		$this->object_type = 'term';
 	}
 
 	/**

--- a/inc/providers/class-core-sitemaps-taxonomies.php
+++ b/inc/providers/class-core-sitemaps-taxonomies.php
@@ -25,13 +25,33 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 	}
 
 	/**
+	 * Returns all public, registered taxonomies.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @return array Map of registered taxonomy objects keyed by their name.
+	 */
+	public function get_object_subtypes() {
+		$taxonomies = get_taxonomies( array( 'public' => true ), 'objects' );
+
+		/**
+		 * Filter the list of taxonomy object subtypes available within the sitemap.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param array $taxonomies Map of registered taxonomy objects keyed by their name.
+		 */
+		return apply_filters( 'core_sitemaps_taxonomies', $taxonomies );
+	}
+
+	/**
 	 * Gets a URL list for a taxonomy sitemap.
 	 *
 	 * @since 5.5.0
 	 *
 	 * @param int    $page_num Page of results.
 	 * @param string $taxonomy Optional. Taxonomy name. Default empty.
-	 * @return array $url_list List of URLs for a sitemap.
+	 * @return array List of URLs for a sitemap.
 	 */
 	public function get_url_list( $page_num, $taxonomy = '' ) {
 		// Find the query_var for subtype.
@@ -93,24 +113,6 @@ class Core_Sitemaps_Taxonomies extends Core_Sitemaps_Provider {
 		 * @param int    $page_num Page of results.
 		 */
 		return apply_filters( 'core_sitemaps_taxonomies_url_list', $url_list, $taxonomy, $page_num );
-	}
-
-	/**
-	 * Returns all public, registered taxonomies.
-	 *
-	 * @since 5.5.0
-	 */
-	public function get_object_subtypes() {
-		$taxonomies = get_taxonomies( array( 'public' => true ), 'objects' );
-
-		/**
-		 * Filter the list of taxonomy object subtypes available within the sitemap.
-		 *
-		 * @since 5.5.0
-		 *
-		 * @param array $taxonomies List of registered taxonomy names.
-		 */
-		return apply_filters( 'core_sitemaps_taxonomies', $taxonomies );
 	}
 
 	/**

--- a/inc/providers/class-core-sitemaps-users.php
+++ b/inc/providers/class-core-sitemaps-users.php
@@ -33,7 +33,7 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * @param string $object_subtype Optional. Not applicable for Users but
 	 *                               required for compatibility with the parent
 	 *                               provider class. Default empty.
-	 * @return array $url_list List of URLs for a sitemap.
+	 * @return array List of URLs for a sitemap.
 	 */
 	public function get_url_list( $page_num, $object_subtype = '' ) {
 		$query    = $this->get_public_post_authors_query( $page_num );

--- a/inc/providers/class-core-sitemaps-users.php
+++ b/inc/providers/class-core-sitemaps-users.php
@@ -21,7 +21,8 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * @since 5.5.0
 	 */
 	public function __construct() {
-		$this->object_type = 'users';
+		$this->name        = 'users';
+		$this->object_type = 'user';
 	}
 
 	/**

--- a/inc/providers/class-core-sitemaps-users.php
+++ b/inc/providers/class-core-sitemaps-users.php
@@ -29,12 +29,13 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param int    $page_num Page of results.
-	 * @param string $type     Optional. Not applicable for Users but required for
-	 *                         compatibility with the parent provider class. Default ''.
+	 * @param int    $page_num       Page of results.
+	 * @param string $object_subtype Optional. Not applicable for Users but
+	 *                               required for compatibility with the parent
+	 *                               provider class. Default empty.
 	 * @return array $url_list List of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num, $type = '' ) {
+	public function get_url_list( $page_num, $object_subtype = '' ) {
 		$query    = $this->get_public_post_authors_query( $page_num );
 		$users    = $query->get_results();
 		$url_list = array();
@@ -62,10 +63,13 @@ class Core_Sitemaps_Users extends Core_Sitemaps_Provider {
 	 * @since 5.5.0
 	 *
 	 * @see Core_Sitemaps_Provider::max_num_pages
-	 * @param string $type Optional. Name of the object type. Default is null.
+	 *
+	 * @param string $object_subtype Optional. Not applicable for Users but
+	 *                               required for compatibility with the parent
+	 *                               provider class. Default empty.
 	 * @return int Total page count.
 	 */
-	public function max_num_pages( $type = '' ) {
+	public function max_num_pages( $object_subtype = '' ) {
 		$query = $this->get_public_post_authors_query();
 
 		$total_users = $query->get_total();

--- a/tests/phpunit/functions.php
+++ b/tests/phpunit/functions.php
@@ -8,12 +8,10 @@ class Test_Core_Sitemaps_Functions extends WP_UnitTestCase {
 		// Apply a filter to test filterable values.
 		add_filter( 'core_sitemaps_max_urls', array( $this, '_filter_max_url_value' ), 10, 2 );
 
-		$expected_null = core_sitemaps_get_max_urls();
 		$expected_posts = core_sitemaps_get_max_urls( 'posts' );
 		$expected_taxonomies = core_sitemaps_get_max_urls( 'taxonomies' );
 		$expected_users = core_sitemaps_get_max_urls( 'users' );
 
-		$this->assertEquals( $expected_null, CORE_SITEMAPS_MAX_URLS, 'Can not confirm max URL number.' );
 		$this->assertEquals( $expected_posts, 300, 'Can not confirm max URL number for posts.' );
 		$this->assertEquals( $expected_taxonomies, 50, 'Can not confirm max URL number for taxonomies.' );
 		$this->assertEquals( $expected_users, 1, 'Can not confirm max URL number for users.' );

--- a/tests/phpunit/functions.php
+++ b/tests/phpunit/functions.php
@@ -8,9 +8,9 @@ class Test_Core_Sitemaps_Functions extends WP_UnitTestCase {
 		// Apply a filter to test filterable values.
 		add_filter( 'core_sitemaps_max_urls', array( $this, '_filter_max_url_value' ), 10, 2 );
 
-		$expected_posts = core_sitemaps_get_max_urls( 'posts' );
-		$expected_taxonomies = core_sitemaps_get_max_urls( 'taxonomies' );
-		$expected_users = core_sitemaps_get_max_urls( 'users' );
+		$expected_posts = core_sitemaps_get_max_urls( 'post' );
+		$expected_taxonomies = core_sitemaps_get_max_urls( 'term' );
+		$expected_users = core_sitemaps_get_max_urls( 'user' );
 
 		$this->assertEquals( $expected_posts, 300, 'Can not confirm max URL number for posts.' );
 		$this->assertEquals( $expected_taxonomies, 50, 'Can not confirm max URL number for taxonomies.' );
@@ -26,11 +26,11 @@ class Test_Core_Sitemaps_Functions extends WP_UnitTestCase {
 	 */
 	public function _filter_max_url_value( $max_urls, $type ) {
 		switch ( $type ) {
-			case 'posts':
+			case 'post':
 				return 300;
-			case 'taxonomies':
+			case 'term':
 				return 50;
-			case 'users':
+			case 'user':
 				return 1;
 			default:
 				return $max_urls;

--- a/tests/phpunit/inc/class-core-sitemaps-test-provider.php
+++ b/tests/phpunit/inc/class-core-sitemaps-test-provider.php
@@ -24,19 +24,34 @@ class Core_Sitemaps_Test_Provider extends Core_Sitemaps_Provider {
 	 * Return the public post types, which excludes nav_items and similar types.
 	 * Attachments are also excluded. This includes custom post types with public = true
 	 *
-	 * @return array $post_types List of registered object sub types.
+	 * @return array Map of object subtype objects keyed by their name.
 	 */
 	public function get_object_subtypes() {
-		return array( 'type-1', 'type-2', 'type-3' );
+		return array(
+			'type-1' => (object) array( 'name' => 'type-1' ),
+			'type-2' => (object) array( 'name' => 'type-2' ),
+			'type-3' => (object) array( 'name' => 'type-3' ),
+		);
+	}
+
+	/**
+	 * Gets a URL list for a sitemap.
+	 *
+	 * @param int    $page_num       Page of results.
+	 * @param string $object_subtype Optional. Object subtype name. Default empty.
+	 * @return array List of URLs for a sitemap.
+	 */
+	public function get_url_list( $page_num, $object_subtype = '' ) {
+		return array();
 	}
 
 	/**
 	 * Query for determining the number of pages.
 	 *
-	 * @param string $type Optional. Object type. Default is null.
+	 * @param string $object_subtype Optional. Object subtype. Default empty.
 	 * @return int Total number of pages.
 	 */
-	public function max_num_pages( $type = '' ) {
+	public function max_num_pages( $object_subtype = '' ) {
 		return 4;
 	}
 }

--- a/tests/phpunit/inc/class-core-sitemaps-test-provider.php
+++ b/tests/phpunit/inc/class-core-sitemaps-test-provider.php
@@ -26,7 +26,7 @@ class Core_Sitemaps_Test_Provider extends Core_Sitemaps_Provider {
 	 *
 	 * @return array $post_types List of registered object sub types.
 	 */
-	public function get_object_sub_types() {
+	public function get_object_subtypes() {
 		return array( 'type-1', 'type-2', 'type-3' );
 	}
 

--- a/tests/phpunit/sitemaps-posts.php
+++ b/tests/phpunit/sitemaps-posts.php
@@ -9,7 +9,7 @@ class Test_Core_Sitemaps_Posts extends WP_UnitTestCase {
 
 		// Return an empty array to show that the list of subtypes is filterable.
 		add_filter( 'core_sitemaps_post_types', '__return_empty_array' );
-		$subtypes = $posts_provider->get_object_sub_types();
+		$subtypes = $posts_provider->get_object_subtypes();
 
 		$this->assertEquals( array(), $subtypes, 'Could not filter posts subtypes.' );
 	}

--- a/tests/phpunit/sitemaps-taxonomies.php
+++ b/tests/phpunit/sitemaps-taxonomies.php
@@ -182,7 +182,7 @@ class Test_Core_Sitemaps_Taxonomies extends WP_UnitTestCase {
 
 		// Return an empty array to show that the list of subtypes is filterable.
 		add_filter( 'core_sitemaps_taxonomies', '__return_empty_array' );
-		$subtypes = $taxonomies_provider->get_object_sub_types();
+		$subtypes = $taxonomies_provider->get_object_subtypes();
 
 		$this->assertEquals( array(), $subtypes, 'Could not filter taxonomies subtypes.' );
 	}


### PR DESCRIPTION
### Issue Number
Fixes https://github.com/GoogleChromeLabs/wp-sitemaps/issues/91

### Description
This PR ensures object subtypes are documented properly and correct variable and method names using `object_subtype` are in place.

* Rename `type` / `sub_type` to `object_subtype` (or in few instances `object_type`) where applicable. In the respective provider sub-classes I opted to reference object subtypes in a less abstract way as `post_type` / `taxonomy`.
* Make `Core_Sitemaps_Provider` abstract, there was no purpose in not having it abstract, and it contained some post-specific code and documentation, which should not be the case.
* Fix inconsistency in what the `get_object_subtypes()` method returns: it sometimes was a list of names, sometimes a keyed map of objects. Now it is always the latter, since that allows for fast `isset` checks on keys as well as easy usage of the post-/taxonomy-specific filters.
* Clarify `core_sitemaps_get_max_urls()` parameter and make it mandatory, since there is no point in having it optional, and having it empty would be unexpected for the filter usage.
* Fix object type names to be `post`, `term`, `user`, as already defined by core. The `posts`, `taxonomies`, `users` names have been kept as provider-specific names, e.g. to be used in URLs as they are now. I wonder whether we should go a bit further and eliminate usage of these throughout the codebase so that the _only_ become necessary for URLs (e.g. we could rename the `Core_Sitemaps_Provider::$name` property to `Core_Sitemaps_Provider::$url_query_value` or something). That would simplify the codebase so that we'd always use the object type as provider identifier and not the "arbitrary" strings introduced for URL purposes.
* Fix some inaccurate documentation and use core conventions (e.g. no variable names in return type docs, "taxonomy type" -> "taxonomy", "Default ''." --> "Default empty.").

### Type of change
Please select the relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
