### PR TITLE
Bail early if there are no sitemap entries

### DIFF
--- a/inc/class-core-sitemaps-index.php
+++ b/inc/class-core-sitemaps-index.php
@@ -49,8 +49,15 @@ class Core_Sitemaps_Index {
 		$providers = $this->registry->get_sitemaps();
 		/* @var Core_Sitemaps_Provider $provider */
 		foreach ( $providers as $provider ) {
+			$sitemap_entries = $provider->get_sitemap_entries();
+
+			// Prevent issues with array_push and empty arrays on PHP < 7.3.
+			if ( ! $sitemap_entries ) {
+				continue;
+			}
+
 			// Using array_push is more efficient than array_merge in a loop.
-			array_push( $sitemaps, ...$provider->get_sitemap_entries() );
+			array_push( $sitemaps, ...$sitemap_entries );
 		}
 
 		return $sitemaps;

--- a/tests/phpunit/inc/class-core-sitemaps-empty-test-provider.php
+++ b/tests/phpunit/inc/class-core-sitemaps-empty-test-provider.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Test sitemap provider.
+ *
+ * @package Core_Sitemaps
+ */
+
+/**
+ * Class Core_Sitemaps_Empty_Provider.
+ *
+ * Provides test data for additional registered providers.
+ */
+class Core_Sitemaps_Empty_Test_Provider extends Core_Sitemaps_Provider {
+	/**
+	 * Core_Sitemaps_Posts constructor.
+	 *
+	 * @param string $object_type Optional. Object type name to use. Default 'test'.
+	 */
+	public function __construct( $object_type = 'test' ) {
+		$this->object_type = $object_type;
+	}
+
+	/**
+	 * Return the public post types, which excludes nav_items and similar types.
+	 * Attachments are also excluded. This includes custom post types with public = true
+	 *
+	 * @return array Map of object subtype objects (WP_Post_Type) keyed by their name.
+	 */
+	public function get_object_subtypes() {
+		return array();
+	}
+
+	/**
+	 * Gets a URL list for a sitemap.
+	 *
+	 * @param int    $page_num       Page of results.
+	 * @param string $object_subtype Optional. Object subtype name. Default empty.
+	 * @return array List of URLs for a sitemap.
+	 */
+	public function get_url_list( $page_num, $object_subtype = '' ) {
+		return array();
+	}
+
+	/**
+	 * Query for determining the number of pages.
+	 *
+	 * @param string $object_subtype Optional. Object subtype. Default empty.
+	 * @return int Total number of pages.
+	 */
+	public function max_num_pages( $object_subtype = '' ) {
+		return 0;
+	}
+}

--- a/tests/phpunit/sitemaps-index.php
+++ b/tests/phpunit/sitemaps-index.php
@@ -17,6 +17,15 @@ class Test_Core_Sitemaps_Index extends WP_UnitTestCase {
 		$this->assertCount( 24, $sitemap_index->get_sitemap_list() );
 	}
 
+	public function test_get_sitemap_list_no_entries() {
+		$registry = new Core_Sitemaps_Registry();
+
+		$registry->add_sitemap( 'foo', new Core_Sitemaps_Empty_Test_Provider( 'foo' ) );
+
+		$sitemap_index = new Core_Sitemaps_Index( $registry );
+		$this->assertCount( 0, $sitemap_index->get_sitemap_list() );
+	}
+
 	public function test_get_index_url() {
 		$sitemap_index = new Core_Sitemaps_Index( new Core_Sitemaps_Registry() );
 		$index_url = $sitemap_index->get_index_url();

--- a/tests/phpunit/sitemaps-registry.php
+++ b/tests/phpunit/sitemaps-registry.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once( __DIR__ . '/inc/class-core-sitemaps-test-provider.php' );
-
 class Test_Core_Sitemaps_Registry extends WP_UnitTestCase {
 	public function test_add_sitemap() {
 		$provider = new Core_Sitemaps_Test_Provider();

--- a/tests/phpunit/sitemaps.php
+++ b/tests/phpunit/sitemaps.php
@@ -10,8 +10,6 @@
  * @link      https://github.com/GoogleChromeLabs/wp-sitemaps
  */
 
-require_once( __DIR__ . '/inc/class-core-sitemaps-test-provider.php' );
-
 /**
  * Core sitemaps test cases.
  *

--- a/tests/wp-tests-bootstrap.php
+++ b/tests/wp-tests-bootstrap.php
@@ -75,3 +75,6 @@ tests_add_filter(
  * @noinspection PhpIncludeInspection
  */
 require $core_sitemaps_tests_dir . '/includes/bootstrap.php';
+
+require_once( __DIR__ . '/phpunit/inc/class-core-sitemaps-test-provider.php' );
+require_once( __DIR__ . '/phpunit/inc/class-core-sitemaps-empty-test-provider.php' );


### PR DESCRIPTION
### Issue Number

Fixes #186.

### Description

On PHP < 7.3, `array_push` emits a warning if the second param is an empty array. See https://3v4l.org/Pk7En and https://www.php.net/manual/en/function.array-push.php

This PR checks whether the sitemap entries array is empty before trying to `array_push` it.

### Type of change
Please select the relevant options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test

Run tests on PHP < 7.3

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
