### PR TITLE
Add new filters for individual sitemap entries

### DIFF
--- a/inc/providers/class-wp-sitemaps-posts.php
+++ b/inc/providers/class-wp-sitemaps-posts.php
@@ -103,9 +103,21 @@ class WP_Sitemaps_Posts extends WP_Sitemaps_Provider {
 		}
 
 		foreach ( $posts as $post ) {
-			$url_list[] = array(
+			$sitemap_entry = array(
 				'loc' => get_permalink( $post ),
 			);
+
+			/**
+			 * Filters the sitemap entry for an individual post.
+			 *
+			 * @since 5.5.0
+			 *
+			 * @param array   $sitemap_entry Sitemap entry for the post.
+			 * @param WP_Post $post          Post object.
+			 * @param string  $post_type     Name of the post_type.
+			 */
+			$sitemap_entry = apply_filters( 'wp_sitemaps_posts_entry', $sitemap_entry, $post, $post_type );
+			$url_list[] = $sitemap_entry;
 		}
 
 		/**

--- a/inc/providers/class-wp-sitemaps-taxonomies.php
+++ b/inc/providers/class-wp-sitemaps-taxonomies.php
@@ -98,9 +98,21 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 
 		if ( ! empty( $taxonomy_terms->terms ) ) {
 			foreach ( $taxonomy_terms->terms as $term ) {
-				$url_list[] = array(
+				$sitemap_entry = array(
 					'loc' => get_term_link( $term ),
 				);
+
+				/**
+				 * Filters the sitemap entry for an individual term.
+				 *
+				 * @since 5.5.0
+				 *
+				 * @param array   $sitemap_entry Sitemap entry for the term.
+				 * @param WP_Term $term          Term object.
+				 * @param string  $taxonomy      Taxonomy name.
+				 */
+				$sitemap_entry = apply_filters( 'wp_sitemaps_taxonomies_entry', $sitemap_entry, $term, $taxonomy );
+				$url_list[] = $sitemap_entry;
 			}
 		}
 

--- a/inc/providers/class-wp-sitemaps-users.php
+++ b/inc/providers/class-wp-sitemaps-users.php
@@ -42,9 +42,20 @@ class WP_Sitemaps_Users extends WP_Sitemaps_Provider {
 		$url_list = array();
 
 		foreach ( $users as $user ) {
-			$url_list[] = array(
+			$sitemap_entry = array(
 				'loc'     => get_author_posts_url( $user->ID ),
 			);
+
+			/**
+			 * Filters the sitemap entry for an individual user.
+			 *
+			 * @since 5.5.0
+			 *
+			 * @param array   $sitemap_entry Sitemap entry for the user.
+			 * @param WP_User $user          User object.
+			 */
+			$sitemap_entry = apply_filters( 'wp_sitemaps_users_entry', $sitemap_entry, $user );
+			$url_list[] = $sitemap_entry;
 		}
 
 		/**


### PR DESCRIPTION
### Issue Number

Fixes #188.
Fixes #189.

### Description

Adds new filters to more easily add custom attributes for individual items, providing post/term/user objects to the consumer.

### Screenshots (before and after if applicable)
N/A

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
Describe the tests required to verify your changes.
Provide instructions so the PR Tester can check functionality and also list any relevant details and / or dependencies required for your tests.

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
