### PR TITLE
Remove `*_url_list` filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ add_filter(
 	'wp_sitemaps_posts_query_args',
 	function( $args ) {
 		$args['post__not_in'] = isset( $args['post__not_in'] ) ? $args['post__not_in'] : array();
-		$args['post__not_in'][] 42;
+		$args['post__not_in'][] = 42;
 		return $args;
 	}
 );
@@ -82,7 +82,7 @@ add_filter(
 	'wp_sitemaps_taxonomies_query_args',
 	function( $args ) {
 		$args['exclude'] = isset( $args['exclude'] ) ? $args['exclude'] : array();
-		$args['exclude'][] 7;
+		$args['exclude'][] = 7;
 		return $args;
 	}
 );
@@ -95,7 +95,7 @@ add_filter(
 	'wp_sitemaps_users_query_args',
 	function( $args ) {
 		$args['exclude'] = isset( $args['exclude'] ) ? $args['exclude'] : array();
-		$args['exclude'][] 1;
+		$args['exclude'][] = 1;
 		return $args;
 	}
 );

--- a/README.md
+++ b/README.md
@@ -60,45 +60,31 @@ add_filter(
 
 ### How can I exclude certain posts / taxonomies / users from the sitemap or add custom ones?
 
-The `wp_sitemaps_taxonomies_url_list`, `wp_sitemaps_taxonomies_url_list`, and `wp_sitemaps_users_url_list` filters allow you to add or remove URLs as needed.
+The `wp_sitemaps_posts_query_args`, `wp_sitemaps_taxonomies_query_args`, and `wp_sitemaps_users_query_args` filters can be used to modify the underlying queries. Using these queries, certain items can be excluded.
 
 **Example: Ensuring the page with ID 42 is not included**
 
 ```php
 add_filter(
-	'wp_sitemaps_posts_url_list',
-	function( $urls, $type ) {
-		if ( 'page' === $type ) {
-			$post_to_remove = array( 'loc' => get_permalink( 42 ) );
-			$key = array_search( $post_to_remove, $urls, true );
-			if ( false !== $key ) {
-				array_splice( $urls, $key, 1 );
-			}
-		}
-		return $urls;
-	},
-	10,
-	2
+	'wp_sitemaps_posts_query_args',
+	function( $args ) {
+		$args['post__not_in'] = isset( $args['post__not_in'] ) ? $args['post__not_in'] : array();
+		$args['post__not_in'][] 42;
+		return $args;
+	}
 );
 ```
 
-**Example: Ensuring the category with ID 1 is not included**
+**Example: Ensuring the category with ID 7 is not included**
 
 ```php
 add_filter(
-	'wp_sitemaps_taxonomies_url_list',
-	function( $urls, $type ) {
-		if ( 'category' === $type ) {
-			$term_to_remove = array( 'loc' => get_term_link( 1 ) );
-			$key = array_search( $term_to_remove, $urls, true );
-			if ( false !== $key ) {
-				array_splice( $urls, $key, 1 );
-			}
-		}
-		return $urls;
-	},
-	10,
-	2
+	'wp_sitemaps_taxonomies_query_args',
+	function( $args ) {
+		$args['exclude'] = isset( $args['exclude'] ) ? $args['exclude'] : array();
+		$args['exclude'][] 7;
+		return $args;
+	}
 );
 ```
 
@@ -106,14 +92,11 @@ add_filter(
 
 ```php
 add_filter(
-	'wp_sitemaps_users_url_list',
-	function( $urls ) {
-		$user_to_remove = array( 'loc' => get_author_posts_url( 1 ) );
-		$key = array_search( $user_to_remove, $urls, true );
-		if ( false !== $key ) {
-			array_splice( $urls, $key, 1 );
-		}
-		return $urls;
+	'wp_sitemaps_users_query_args',
+	function( $args ) {
+		$args['exclude'] = isset( $args['exclude'] ) ? $args['exclude'] : array();
+		$args['exclude'][] 1;
+		return $args;
 	}
 );
 ```

--- a/inc/providers/class-wp-sitemaps-posts.php
+++ b/inc/providers/class-wp-sitemaps-posts.php
@@ -108,16 +108,7 @@ class WP_Sitemaps_Posts extends WP_Sitemaps_Provider {
 			);
 		}
 
-		/**
-		 * Filters the array of URLs for a sitemap before rendering.
-		 *
-		 * @since 5.5.0
-		 *
-		 * @param array  $url_list  Array of URLs for a sitemap.
-		 * @param string $post_type Name of the post_type.
-		 * @param int    $page_num  Page number of the results.
-		 */
-		return apply_filters( 'wp_sitemaps_posts_url_list', $url_list, $post_type, $page_num );
+		return $url_list;
 	}
 
 	/**

--- a/inc/providers/class-wp-sitemaps-taxonomies.php
+++ b/inc/providers/class-wp-sitemaps-taxonomies.php
@@ -104,16 +104,7 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 			}
 		}
 
-		/**
-		 * Filters the array of URLs for a sitemap. before rendering.
-		 *
-		 * @since 5.5.0
-		 *
-		 * @param array  $url_list Array of URLs for a sitemap.
-		 * @param string $taxonomy Taxonomy name.
-		 * @param int    $page_num Page of results.
-		 */
-		return apply_filters( 'wp_sitemaps_taxonomies_url_list', $url_list, $taxonomy, $page_num );
+		return $url_list;
 	}
 
 	/**

--- a/inc/providers/class-wp-sitemaps-users.php
+++ b/inc/providers/class-wp-sitemaps-users.php
@@ -47,15 +47,7 @@ class WP_Sitemaps_Users extends WP_Sitemaps_Provider {
 			);
 		}
 
-		/**
-		 * Filters the array of URLs for a sitemap. before rendering.
-		 *
-		 * @since 5.5.0
-		 *
-		 * @param array  $url_list Array of URLs for a sitemap.
-		 * @param int    $page_num Page of results.
-		 */
-		return apply_filters( 'wp_sitemaps_users_url_list', $url_list, $page_num );
+		return $url_list;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -85,7 +85,7 @@ add_filter(
 	'wp_sitemaps_posts_query_args',
 	function( $args ) {
 		$args['post__not_in'] = isset( $args['post__not_in'] ) ? $args['post__not_in'] : array();
-		$args['post__not_in'][] 42;
+		$args['post__not_in'][] = 42;
 		return $args;
 	}
 );
@@ -98,7 +98,7 @@ add_filter(
 	'wp_sitemaps_taxonomies_query_args',
 	function( $args ) {
 		$args['exclude'] = isset( $args['exclude'] ) ? $args['exclude'] : array();
-		$args['exclude'][] 7;
+		$args['exclude'][] = 7;
 		return $args;
 	}
 );
@@ -111,7 +111,7 @@ add_filter(
 	'wp_sitemaps_users_query_args',
 	function( $args ) {
 		$args['exclude'] = isset( $args['exclude'] ) ? $args['exclude'] : array();
-		$args['exclude'][] 1;
+		$args['exclude'][] = 1;
 		return $args;
 	}
 );

--- a/readme.txt
+++ b/readme.txt
@@ -76,45 +76,31 @@ add_filter(
 
 = How can I exclude certain posts / taxonomies / users from the sitemap or add custom ones? =
 
-The `wp_sitemaps_taxonomies_url_list`, `wp_sitemaps_taxonomies_url_list`, and `wp_sitemaps_users_url_list` filters allow you to add or remove URLs as needed.
+The `wp_sitemaps_posts_query_args`, `wp_sitemaps_taxonomies_query_args`, and `wp_sitemaps_users_query_args` filters can be used to modify the underlying queries. Using these queries, certain items can be excluded.
 
 **Example: Ensuring the page with ID 42 is not included**
 
 ```php
 add_filter(
-	'wp_sitemaps_posts_url_list',
-	function( $urls, $type ) {
-		if ( 'page' === $type ) {
-			$post_to_remove = array( 'loc' => get_permalink( 42 ) );
-			$key = array_search( $post_to_remove, $urls, true );
-			if ( false !== $key ) {
-				array_splice( $urls, $key, 1 );
-			}
-		}
-		return $urls;
-	},
-	10,
-	2
+	'wp_sitemaps_posts_query_args',
+	function( $args ) {
+		$args['post__not_in'] = isset( $args['post__not_in'] ) ? $args['post__not_in'] : array();
+		$args['post__not_in'][] 42;
+		return $args;
+	}
 );
 ```
 
-**Example: Ensuring the category with ID 1 is not included**
+**Example: Ensuring the category with ID 7 is not included**
 
 ```php
 add_filter(
-	'wp_sitemaps_taxonomies_url_list',
-	function( $urls, $type ) {
-		if ( 'category' === $type ) {
-			$term_to_remove = array( 'loc' => get_term_link( 1 ) );
-			$key = array_search( $term_to_remove, $urls, true );
-			if ( false !== $key ) {
-				array_splice( $urls, $key, 1 );
-			}
-		}
-		return $urls;
-	},
-	10,
-	2
+	'wp_sitemaps_taxonomies_query_args',
+	function( $args ) {
+		$args['exclude'] = isset( $args['exclude'] ) ? $args['exclude'] : array();
+		$args['exclude'][] 7;
+		return $args;
+	}
 );
 ```
 
@@ -122,14 +108,11 @@ add_filter(
 
 ```php
 add_filter(
-	'wp_sitemaps_users_url_list',
-	function( $urls ) {
-		$user_to_remove = array( 'loc' => get_author_posts_url( 1 ) );
-		$key = array_search( $user_to_remove, $urls, true );
-		if ( false !== $key ) {
-			array_splice( $urls, $key, 1 );
-		}
-		return $urls;
+	'wp_sitemaps_users_query_args',
+	function( $args ) {
+		$args['exclude'] = isset( $args['exclude'] ) ? $args['exclude'] : array();
+		$args['exclude'][] 1;
+		return $args;
 	}
 );
 ```

--- a/tests/phpunit/sitemaps-posts.php
+++ b/tests/phpunit/sitemaps-posts.php
@@ -13,24 +13,4 @@ class Test_WP_Sitemaps_Posts extends WP_UnitTestCase {
 
 		$this->assertEquals( array(), $subtypes, 'Could not filter posts subtypes.' );
 	}
-
-	/**
-	 * Test ability to filter the posts URL list.
-	 */
-	public function test_filter_sitemaps_posts_url_list() {
-		$posts_provider = new WP_Sitemaps_Posts();
-
-		add_filter( 'wp_sitemaps_posts_url_list', '__return_empty_array' );
-		// Use 'page' post type with 'show_on_front' set to 'posts' to ensure
-		// this would not be empty without the filter.
-		add_filter(
-			'option_show_on_front',
-			function() {
-				return 'posts';
-			}
-		);
-		$page_url_list = $posts_provider->get_url_list( 1, 'page' );
-
-		$this->assertEquals( array(), $page_url_list, 'Could not filter posts URL list.' );
-	}
 }

--- a/tests/phpunit/sitemaps-taxonomies.php
+++ b/tests/phpunit/sitemaps-taxonomies.php
@@ -186,22 +186,4 @@ class Test_WP_Sitemaps_Taxonomies extends WP_UnitTestCase {
 
 		$this->assertEquals( array(), $subtypes, 'Could not filter taxonomies subtypes.' );
 	}
-
-	/**
-	 * Test ability to filter the taxonomies URL list.
-	 */
-	public function test_filter_sitemaps_taxonomies_url_list() {
-		$taxonomies_provider = new WP_Sitemaps_Taxonomies();
-
-		add_filter( 'wp_sitemaps_taxonomies_url_list', '__return_empty_array' );
-
-		// Register taxonomy, create a term for it and assign a post to it.
-		register_taxonomy( 'test_tax', 'post' );
-		$term = self::factory()->term->create( array( 'taxonomy'  => 'test_tax' ) );
-		$post = self::factory()->post->create();
-		wp_set_post_terms( $post, array( $term ), 'test_tax' );
-
-		$test_tax_url_list = $taxonomies_provider->get_url_list( 1, 'test_tax' );
-		$this->assertEquals( array(), $test_tax_url_list, 'Could not filter taxonomies URL list.' );
-	}
 }

--- a/tests/phpunit/sitemaps-users.php
+++ b/tests/phpunit/sitemaps-users.php
@@ -51,19 +51,4 @@ class Test_WP_Sitemaps_Users extends WP_UnitTestCase {
 
 		$this->assertEqualSets( $expected, $url_list );
 	}
-
-	/**
-	 * Test ability to filter the users URL list.
-	 */
-	public function test_filter_sitemaps_users_url_list() {
-		$users_provider = new WP_Sitemaps_Users();
-
-		add_filter( 'wp_sitemaps_users_url_list', '__return_empty_array' );
-
-		// Create post by an existing user so that they are a post author.
-		self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
-		$user_url_list = $users_provider->get_url_list( 1 );
-
-		$this->assertEquals( array(), $user_url_list, 'Could not filter users URL list.' );
-	}
 }

--- a/tests/phpunit/sitemaps.php
+++ b/tests/phpunit/sitemaps.php
@@ -93,67 +93,6 @@ class Test_Sitemaps extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure URL lists can have attributes added via filters.
-	 *
-	 * @dataProvider _url_list_providers
-	 *
-	 * @param string $type     The object type to test.
-	 * @param string $sub_type The object subtype to use when getting a URL list.
-	 */
-	public function test_add_attributes_to_url_list( $type, $sub_type ) {
-		add_filter( 'wp_sitemaps_' . $type . '_url_list', array( $this, '_add_attributes_to_url_list' ) );
-
-		$providers = wp_get_sitemaps();
-
-		$post_list = $providers[ $type ]->get_url_list( 1, $sub_type );
-
-		foreach ( $post_list as $entry ) {
-			$this->assertEquals( 'value', $entry['extra'], 'Could not add attributes to url lists for ' . $type . '.' );
-		}
-	}
-
-	/**
-	 * Data provider for `test_add_attributes_to_url_list()`.
-	 *
-	 * @return array A list of object types and subtypes.
-	 */
-	public function _url_list_providers() {
-		return array(
-			array(
-				'posts',
-				'post',
-			),
-			array(
-				'taxonomies',
-				'post_tag',
-			),
-			array(
-				'users',
-				'',
-			),
-		);
-	}
-
-	/**
-	 * Filter callback to add an extra value to URL lists.
-	 *
-	 * @param array $url_list Array of URLs from a sitemap provider.
-	 * @return array The filtered URL list.
-	 */
-	public function _add_attributes_to_url_list( $url_list ) {
-		$entries = array_map(
-			static function ( $entry ) {
-				$entry['extra'] = 'value';
-
-				return $entry;
-			},
-			$url_list
-		);
-
-		return $entries;
-	}
-
-	/**
 	 * Helper function to get all sitemap entries data.
 	 *
 	 * @return array A list of sitemap entires.


### PR DESCRIPTION
### Issue Number
Part of #164

### Description
Depends on #183.
Depends by #191.

With those new filters, there isn't really a need for these filters here. They're even more harmful as they could mess with pagination.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test
N/A

### Acceptance criteria
- [x] My code follows WordPress coding standards.
- [x] I have performed a self-review of my own code.
- [x] If the changes are visual, I have cross browser / device tested.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added test instructions that prove my fix is effective or that my feature works.
