### PR TITLE
Refactor `assertXMLEqual()` to work around a bug in `DOMDocument::loadXml()`

### DIFF
--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -234,10 +234,12 @@ class Test_WP_Sitemaps_Renderer extends WP_UnitTestCase {
 		libxml_clear_errors();
 
 		$xml_dom = new DOMDocument();
+		$xml_dom->loadXML( $xml, $options );
+		$libxml_last_error = libxml_get_last_error();
 
-		$this->assertTrue(
-			$xml_dom->loadXML( $xml, $options ),
-			libxml_get_last_error() ? sprintf( 'Non-well-formed XML: %s.', libxml_get_last_error()->message ) : ''
+		$this->assertFalse(
+			isset( $libxml_last_error->message ),
+			isset( $libxml_last_error->message ) ? sprintf( 'Non-well-formed XML: %s.', $libxml_last_error->message ) : ''
 		);
 
 		// Restore default error handler.


### PR DESCRIPTION
### Description
The PHP Manual states that [DOMDocument::loadXml()](https://www.php.net/manual/en/domdocument.loadxml.php) "Returns TRUE on success or FALSE on failure.".  However, that's not 100% true.  If the XML is not-well-formed it _usually_ returns false.  But if it is not-well-formed because **a namespace prefix is used but not declared**, it incorrectly returns true.

Luckily, in all cases of non-well-formed XML (that I've checked), libxml_get_last_error() returns the error.  So, this refactors `Test_WP_Sitemaps_Renderer::loadXml()` (which is used by `Test_WP_Sitemaps_Renderer::assertXMLEqual()`) to check that instead of the return value from `DOMDocument::loadXml()`.

### Type of change
Please select the relevant options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [ ] I have added test instructions that prove my fix is effective or that my feature works.
