### PR TITLE
Limit elements in sitemap entries to those defined in the Sitemaps spec.

### DIFF
--- a/inc/class-wp-sitemaps-renderer.php
+++ b/inc/class-wp-sitemaps-renderer.php
@@ -209,7 +209,7 @@ class WP_Sitemaps_Renderer {
 						__METHOD__,
 						/* translators: %s: list of element names */
 						sprintf(
-							__( 'Fields other than %s are not currently supported for sitemaps', 'core-sitemaps' ),
+							__( 'Fields other than %s are not currently supported for sitemaps.', 'core-sitemaps' ),
 							implode( ',', array( 'loc', 'lastmod', 'changefreq', 'priority' ) )
 						),
 						'5.5.0'

--- a/inc/class-wp-sitemaps-renderer.php
+++ b/inc/class-wp-sitemaps-renderer.php
@@ -198,12 +198,12 @@ class WP_Sitemaps_Renderer {
 		foreach ( $url_list as $url_item ) {
 			$url = $urlset->addChild( 'url' );
 
-			// Add each attribute as a child node to the URL entry.
-			foreach ( $url_item as $attr => $value ) {
-				if ( 'url' === $attr ) {
-					$url->addChild( $attr, esc_url( $value ) );
-				} else {
-					$url->addChild( $attr, esc_attr( $value ) );
+			// Add each element as a child node to the URL entry.
+			foreach ( $url_item as $name => $value ) {
+				if ( 'loc' === $name ) {
+					$url->addChild( $name, esc_url( $value ) );
+				} elseif ( in_array( $name, array( 'lastmod', 'changefreq', 'priority' ), true ) ) {
+					$url->addChild( $name, esc_attr( $value ) );
 				}
 			}
 		}

--- a/inc/class-wp-sitemaps-renderer.php
+++ b/inc/class-wp-sitemaps-renderer.php
@@ -204,6 +204,16 @@ class WP_Sitemaps_Renderer {
 					$url->addChild( $name, esc_url( $value ) );
 				} elseif ( in_array( $name, array( 'lastmod', 'changefreq', 'priority' ), true ) ) {
 					$url->addChild( $name, esc_attr( $value ) );
+				} else {
+					_doing_it_wrong(
+						__METHOD__,
+						/* translators: %s: list of element names */
+						sprintf(
+							__( 'Fields other than %s are not currently supported for sitemaps', 'core-sitemaps' ),
+							implode( ',', array( 'loc', 'lastmod', 'changefreq', 'priority' ) )
+						),
+						'5.5.0'
+					);
 				}
 			}
 		}

--- a/inc/class-wp-sitemaps-stylesheet.php
+++ b/inc/class-wp-sitemaps-stylesheet.php
@@ -52,62 +52,85 @@ class WP_Sitemaps_Stylesheet {
 		$text        = sprintf(
 			/* translators: %s: number of URLs. */
 			__( 'Number of URLs in this XML Sitemap: %s.', 'core-sitemaps' ),
-			'<xsl:value-of select="count(sitemap:urlset/sitemap:url)"/>'
+			'<xsl:value-of select="count( sitemap:urlset/sitemap:url )" />'
 		);
 
-		$url = esc_html__( 'URL', 'core-sitemaps' );
+		$lang       = get_language_attributes( 'html' );
+		$url        = esc_html__( 'URL', 'core-sitemaps' );
+		$lastmod    = esc_html__( 'Last Modified', 'core-sitemaps' );
+		$changefreq = esc_html__( 'Change Frequency', 'core-sitemaps' );
+		$priority   = esc_html__( 'Priority', 'core-sitemaps' );
 
 		$xsl_content = <<<XSL
 <?xml version="1.0" encoding="UTF-8"?>
-			<xsl:stylesheet version="2.0"
-				xmlns:html="http://www.w3.org/TR/REC-html40"
-				xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
-				xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
-				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-			<xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
-			<xsl:template match="/">
-				<html xmlns="http://www.w3.org/1999/xhtml">
-				<head>
-					<title>$title</title>
-					<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-					<style type="text/css">
-						$css
-					</style>
-				</head>
-				<body>
-					<div id="sitemap__header">
-						<h1>$title</h1>
-						<p>$description</p>
-					</div>
-					<div id="sitemap__content">
-						<p class="text">$text</p>
-						<table id="sitemap__table">
-							<thead>
+<xsl:stylesheet
+		version="1.0"
+		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+		xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
+		exclude-result-prefixes="sitemap"
+		>
+
+	<xsl:output method="html" encoding="UTF-8" indent="yes"/>
+
+	<!--
+	  Set variables for whether lastmod, changefreq or priority occur for any url in the sitemap.
+	  We do this up front because it can be expensive in a large sitemap.
+	  -->
+	<xsl:variable name="has-lastmod"    select="count( /sitemap:urlset/sitemap:url/sitemap:lastmod )"    />
+	<xsl:variable name="has-changefreq" select="count( /sitemap:urlset/sitemap:url/sitemap:changefreq )" />
+	<xsl:variable name="has-priority"   select="count( /sitemap:urlset/sitemap:url/sitemap:priority )"   />
+
+	<xsl:template match="/">
+		<html {$lang}>
+			<head>
+				<title>{$title}</title>
+				<style>{$css}</style>
+			</head>
+			<body>
+				<div id="sitemap__header">
+					<h1>{$title}</h1>
+					<p>{$description}</p>
+				</div>
+				<div id="sitemap__content">
+					<p class="text">{$text}</p>
+					<table id="sitemap__table">
+						<thead>
 							<tr>
-								<th>$url</th>
+								<th class="loc">{$url}</th>
+								<xsl:if test="\$has-lastmod">
+									<th class="lastmod">{$lastmod}</th>
+								</xsl:if>
+								<xsl:if test="\$has-changefreq">
+									<th class="changefreq">{$changefreq}</th>
+								</xsl:if>
+								<xsl:if test="\$has-priority">
+									<th class="priority">{$priority}</th>
+								</xsl:if>
 							</tr>
-							</thead>
-							<tbody>
+						</thead>
+						<tbody>
 							<xsl:for-each select="sitemap:urlset/sitemap:url">
 								<tr>
-									<td>
-										<xsl:variable name="itemURL">
-											<xsl:value-of select="sitemap:loc"/>
-										</xsl:variable>
-										<a href="{\$itemURL}">
-											<xsl:value-of select="sitemap:loc"/>
-										</a>
-									</td>
+									<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
+									<xsl:if test="\$has-lastmod">
+										<td class="lastmod"><xsl:value-of select="sitemap:lastmod" /></td>
+									</xsl:if>
+									<xsl:if test="\$has-changefreq">
+										<td class="changefreq"><xsl:value-of select="sitemap:changefreq" /></td>
+									</xsl:if>
+									<xsl:if test="\$has-priority">
+										<td class="priority"><xsl:value-of select="sitemap:priority" /></td>
+									</xsl:if>
 								</tr>
 							</xsl:for-each>
-							</tbody>
-						</table>
+						</tbody>
+					</table>
+				</div>
+			</body>
+		</html>
+	</xsl:template>
+</xsl:stylesheet>
 
-					</div>
-				</body>
-				</html>
-			</xsl:template>
-			</xsl:stylesheet>\n
 XSL;
 
 		/**
@@ -135,63 +158,56 @@ XSL;
 		);
 		$text        = sprintf(
 			/* translators: %s: number of URLs. */
-			__( 'This XML Sitemap contains %s URLs.', 'core-sitemaps' ),
-			'<xsl:value-of select="count(sitemap:sitemapindex/sitemap:sitemap)"/>'
+			__( 'Number of URLs in this XML Sitemap: %s.', 'core-sitemaps' ),
+			'<xsl:value-of select="count( sitemap:sitemapindex/sitemap:sitemap )" />'
 		);
-
-		$url = esc_html__( 'URL', 'core-sitemaps' );
+		$lang        = get_language_attributes( 'html' );
+		$url         = esc_html__( 'URL', 'core-sitemaps' );
 
 		$xsl_content = <<<XSL
 <?xml version="1.0" encoding="UTF-8"?>
-			<xsl:stylesheet version="2.0"
-				xmlns:html="http://www.w3.org/TR/REC-html40"
-				xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
-				xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
-				xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-			<xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
-			<xsl:template match="/">
-				<html xmlns="http://www.w3.org/1999/xhtml">
-				<head>
-					<title>$title</title>
-					<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-					<style type="text/css">
-						$css
-					</style>
-				</head>
-				<body>
-					<div id="sitemap__header">
-						<h1>$title</h1>
-						<p>$description</p>
-					</div>
-					<div id="sitemap__content">
-						<p class="text">$text</p>
-						<table id="sitemap__table">
-							<thead>
+<xsl:stylesheet
+		version="1.0"
+		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+		xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
+		exclude-result-prefixes="sitemap"
+		>
+
+	<xsl:output method="html" encoding="UTF-8" indent="yes" />
+
+	<xsl:template match="/">
+		<html {$lang}>
+			<head>
+				<title>{$title}</title>
+				<style>{$css}</style>
+			</head>
+			<body>
+				<div id="sitemap__header">
+					<h1>{$title}</h1>
+					<p>{$description}</p>
+				</div>
+				<div id="sitemap__content">
+					<p class="text">{$text}</p>
+					<table id="sitemap__table">
+						<thead>
 							<tr>
-								<th>$url</th>
+								<th class="loc">{$url}</th>
 							</tr>
-							</thead>
-							<tbody>
+						</thead>
+						<tbody>
 							<xsl:for-each select="sitemap:sitemapindex/sitemap:sitemap">
 								<tr>
-									<td>
-										<xsl:variable name="itemURL">
-											<xsl:value-of select="sitemap:loc"/>
-										</xsl:variable>
-										<a href="{\$itemURL}">
-											<xsl:value-of select="sitemap:loc"/>
-										</a>
-									</td>
+									<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
 								</tr>
 							</xsl:for-each>
-							</tbody>
-						</table>
+						</tbody>
+					</table>
+				</div>
+			</body>
+		</html>
+	</xsl:template>
+</xsl:stylesheet>
 
-					</div>
-				</body>
-				</html>
-			</xsl:template>
-			</xsl:stylesheet>\n
 XSL;
 
 		/**

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -174,6 +174,8 @@ class Test_WP_Sitemaps_Renderer extends WP_UnitTestCase {
 	 *
 	 * Note that when a means of adding elements in extension namespaces is settled on,
 	 * this test will need to be updated accordingly.
+	 *
+	 * @expectedIncorrectUsage WP_Sitemaps_Renderer::get_sitemap_xml
 	 */
 	public function test_get_sitemap_xml_extra_elements() {
 		$url_list = array(

--- a/tests/phpunit/sitemaps-renderer.php
+++ b/tests/phpunit/sitemaps-renderer.php
@@ -169,9 +169,13 @@ class Test_WP_Sitemaps_Renderer extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure extra attributes added to URL lists are included in rendered XML.
+	 * Test that all children of Q{http://www.sitemaps.org/schemas/sitemap/0.9}url in the rendered XML
+	 * defined in the Sitemaps spec (i.e., loc, lastmod, changefreq, priority).
+	 *
+	 * Note that when a means of adding elements in extension namespaces is settled on,
+	 * this test will need to be updated accordingly.
 	 */
-	public function test_get_sitemap_xml_extra_attributes() {
+	public function test_get_sitemap_xml_extra_elements() {
 		$url_list = array(
 			array(
 				'loc'     => 'http://' . WP_TESTS_DOMAIN . '/2019/10/post-1',
@@ -187,36 +191,15 @@ class Test_WP_Sitemaps_Renderer extends WP_UnitTestCase {
 
 		$renderer = new WP_Sitemaps_Renderer();
 
-		$xml_dom   = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
-		$xpath    = new DOMXPath( $xml_dom );
+		$xml_dom = $this->loadXML( $renderer->get_sitemap_xml( $url_list ) );
+		$xpath   = new DOMXPath( $xml_dom );
 		$xpath->registerNamespace( 'sitemap', 'http://www.sitemaps.org/schemas/sitemap/0.9' );
 
 		$this->assertEquals(
-			count( $url_list ),
-			$xpath->evaluate( 'count( /sitemap:urlset/sitemap:url/sitemap:string )' ),
-			'Extra string attributes are not being rendered in XML.'
+			0,
+			$xpath->evaluate( "count( /sitemap:urlset/sitemap:url/*[  namespace-uri() != 'http://www.sitemaps.org/schemas/sitemap/0.9' or not( local-name() = 'loc' or local-name() = 'lastmod' or local-name() = 'changefreq' or local-name() = 'priority' ) ] )" ),
+			'Invalid child of "sitemap:url" in rendered XML.'
 		);
-		$this->assertEquals(
-			count( $url_list ),
-			$xpath->evaluate( 'count( /sitemap:urlset/sitemap:url/sitemap:number )' ),
-			'Extra number attributes are not being rendered in XML.'
-		);
-
-		foreach ( $url_list as $idx => $url_item ) {
-			// XPath position() is 1-indexed, so incrememnt $idx accordingly.
-			$idx++;
-
-			$this->assertEquals(
-				$url_item['string'],
-				$xpath->evaluate( "string( /sitemap:urlset/sitemap:url[ {$idx} ]/sitemap:string )" ),
-				'Extra string attributes are not being rendered in XML.'
-			);
-			$this->assertEquals(
-				$url_item['number'],
-				$xpath->evaluate( "string( /sitemap:urlset//sitemap:url[ {$idx} ]/sitemap:number )" ),
-				'Extra number attributes are not being rendered in XML.'
-			);
-		}
 	}
 
 	/**


### PR DESCRIPTION
### Description

#151 and #184 are attempts to provide support for sitemap extensions, but we have yet to come up with a "developer friendly" way of allowing **arbitrary** XML in extension namespaces (including XML attributes!); hence, this follow-up to https://github.com/GoogleChromeLabs/wp-sitemaps/pull/184#issuecomment-636055985.

This PR:

1. limits elements in sitemap entries to those defined in the Sitemaps spec: `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>`
   * also fixes a bug (that I'd never noticed) to ensure that URLs are correctly escaped (previously, the value was escaped when the child name of `url` was `url`...it now correctly checks that the child name is `loc`)
2. updates the sitemap stylesheet to be able to display `<lastmod>`, `<changefreq>` and `<priority>` if they are present in the sitemap
   * a column for one of these elements does **not** appear in the rendered output if the element is not present in the sitemap
   * the columns are always in the order defined in the Sitemaps spec (no custom columns can be added, since no "custom" elements can be added to sitemaps)
   * also adds `html/@lang` (for i18n) and, `th/@class` and `td/@class` (to allow plugins to style the columns, via the exsting `get_stylesheet_css` filter)
3. cleans up the sitemap index stylesheet to be similar in XSLT "style" to the sitemap stylesheet
   * also adds `html/@lang` (for i18n) and, `th/@class` and `td/@class` (to allow plugins to style the columns, via the exsting `get_stylesheet_css` filter)
   * changes the string "This XML Sitemap contains %s URLs" to be "Number of URLs in this XML Sitemap: %s." (the same as for the provider sitemap stylesheet) to avoid i18n problems
4. updates the unit tests
   * `Test_WP_Sitemaps_Renderer::test_get_sitemap_xml_extra_attributes()` renamed to `Test_WP_Sitemaps_Renderer::test_get_sitemap_xml_extra_elements()`, to be more accurate about what it tests :-)
   * reverses the sense of the test.  previously it tested that extra elements were added; now it tests that only elements defined in the Sitemaps spec are added

This PR does **NOT** do any other validation on the generate sitemaps (e.g., all entries contain a `<loc>`,  that the children of `<url>` are in the order defined in the Sitemaps spec, that the value of `<changefreq>` is one of the values enumerated in the Sitemaps spec, etc).  I'll open a separate issue about that.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test

To test that elements other than `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>` are not added to the sitemap do something like:

```
add_filter( 'wp_sitemaps_posts_entry', function( $sitemap_entry ) {
	$sitemap_entry['custom'] = 'custon';

	return $sitemap_entry;
} );
```
and check the resulting XML to verify that no `<custom>` children exist.

To test that additional columns are added to the output rendered by the stylesheet do something like:

```
// see that 'Last Modified' column is rendered when 'lastmod' children appear in the sitemap.
add_filter( 'wp_sitemaps_posts_entry', function( $sitemap_entry ) {
	$sitemap_entry['lastmod'] = 'lastmod';

	return $sitemap_entry;
} );

// see that 'Last Modified' and 'Priority' columns are rendered when 'lastmod' and 'priority'
// children appear in the sitemap.
// also see that columns are in the order defined in the Sitemaps spec even when they are
// added to the entry in a different order.
add_filter( 'wp_sitemaps_taxonomies_entry', function( $sitemap_entry ) {
	$sitemap_entry['priority'] = 'priority';
	$sitemap_entry['lastmod']  = 'lastmod';

	return $sitemap_entry;
} );

// see that values in the table body rows are in the correct columns when an element is added
// to only some entries.
add_filter( 'wp_sitemaps_users_entry', function( $sitemap_entry ) {
	// only add 'lastmod' to some entries.
	if ( random_int( 0, 1 ) ) {
		$sitemap_entry['lastmod'] = 'lastmod';
	}
	$sitemap_entry['priority'] = 'priority';

	return $sitemap_entry;
} );
```

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [X] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have added test instructions that prove my fix is effective or that my feature works.
