### PR TITLE
Add `wp_sitemaps_posts_show_on_front_entry` filter

### DIFF
--- a/inc/providers/class-wp-sitemaps-posts.php
+++ b/inc/providers/class-wp-sitemaps-posts.php
@@ -107,9 +107,19 @@ class WP_Sitemaps_Posts extends WP_Sitemaps_Provider {
 		 */
 		if ( 'page' === $post_type && 1 === $page_num && 'posts' === get_option( 'show_on_front' ) ) {
 			// Extract the data needed for home URL to add to the array.
-			$url_list[] = array(
+			$sitemap_entry = array(
 				'loc' => home_url(),
 			);
+
+			/**
+			 * Filters the sitemap entry for the home page when the 'show_on_front' option equals 'posts'.
+			 *
+			 * @since 5.5.0
+			 *
+			 * @param array $sitemap_entry Sitemap entry for the home page.
+			 */
+			$sitemap_entry = apply_filters( 'wp_sitemaps_posts_show_on_front_entry', $sitemap_entry );
+			$url_list[]    = $sitemap_entry;
 		}
 
 		foreach ( $posts as $post ) {
@@ -127,7 +137,7 @@ class WP_Sitemaps_Posts extends WP_Sitemaps_Provider {
 			 * @param string  $post_type     Name of the post_type.
 			 */
 			$sitemap_entry = apply_filters( 'wp_sitemaps_posts_entry', $sitemap_entry, $post, $post_type );
-			$url_list[] = $sitemap_entry;
+			$url_list[]    = $sitemap_entry;
 		}
 
 		return $url_list;

--- a/tests/phpunit/sitemaps-posts.php
+++ b/tests/phpunit/sitemaps-posts.php
@@ -13,4 +13,36 @@ class Test_WP_Sitemaps_Posts extends WP_UnitTestCase {
 
 		$this->assertEquals( array(), $subtypes, 'Could not filter posts subtypes.' );
 	}
+
+	/**
+	 * Test XML output for the sitemap page renderer.
+	 *
+	 * @group sof
+	 */
+	public function test_posts_show_on_front_entry() {
+		$posts_provider = new WP_Sitemaps_Posts();
+		update_option( 'show_on_front', 'page' );
+
+		add_filter( 'wp_sitemaps_posts_show_on_front_entry', array( $this, '_show_on_front_entry' ) );
+
+		$url_list = $posts_provider->get_url_list( 1, 'page' );
+
+		$this->assertEquals( array(), $url_list );
+
+		update_option( 'show_on_front', 'posts' );
+
+		$url_list      = $posts_provider->get_url_list( 1, 'page' );
+		$sitemap_entry = array_shift( $url_list );
+
+		$this->assertTrue( isset( $sitemap_entry['lastmod'] ) );
+	}
+
+	/**
+	 * Callback for 'wp_sitemaps_posts_show_on_front_entry' filter.
+	 */
+	public function _show_on_front_entry( $sitemap_entry ) {
+		$sitemap_entry['lastmod'] = wp_date( DATE_W3C, time() );
+
+		return $sitemap_entry;
+	}
 }

--- a/tests/phpunit/sitemaps-posts.php
+++ b/tests/phpunit/sitemaps-posts.php
@@ -15,9 +15,7 @@ class Test_WP_Sitemaps_Posts extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test XML output for the sitemap page renderer.
-	 *
-	 * @group sof
+	 * Test `wp_sitemaps_posts_show_on_front_entry` filter.
 	 */
 	public function test_posts_show_on_front_entry() {
 		$posts_provider = new WP_Sitemaps_Posts();


### PR DESCRIPTION
### Issue Number

#206

### Description

Add the `wp_sitemaps_posts_show_on_front_entry` filter.

### Type of change
Please select the relevant options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Steps to test

Ensure that `Settings > Reading > Your homepage displays` is `Your latest posts` and then do something like:

```
add_filter(
	'wp_sitemaps_posts_show_on_front_entry',
	function( $sitemap_entry ) {
		$args = array(
			'post_type'      => 'post',
			'orderby'        => 'modified',
			'order'          => 'DESC',
			'posts_per_page' => 1,
		);
		$posts = get_posts( $args );
		if ( ! $posts ) {
			return $entry;
		}

		$post             = array_shift( $posts );
		$entry['lastmod'] = mysql2date( DATE_W3C, $post->post_modified );

		return $entry;
	}
);
```

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have added test instructions that prove my fix is effective or that my feature works.
