### PR TITLE
Update the check for whether sitemaps exist in core…

### DIFF
--- a/core-sitemaps.php
+++ b/core-sitemaps.php
@@ -21,7 +21,7 @@
  */
 
 // Do not load plugin if WordPress core already has sitemap support.
-if ( function_exists( 'wp_get_sitemaps' ) ) {
+if ( function_exists( 'wp_get_sitemaps' ) || function_exists( 'wp_get_sitemap_providers' ) ) {
 	return;
 }
 


### PR DESCRIPTION
… to account for the change from `wp_get_sitemaps()` to `wp_get_sitemap_providers()` in 5.5 Beta 3.

### Issue Number
Fixes #225.

### Description

This PR adds `function_exists( 'wp_get_sitemap_providers' )` to the check for whether sitemaps exist in core (and renders the feature plugin a no-op).

### Type of change
Please select the relevant options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (change which improves an existing feature. E.g., performance improvement, docs update, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Acceptance criteria
- [X] My code follows WordPress coding standards.
- [X] I have performed a self-review of my own code.
- [ ] If the changes are visual, I have cross browser / device tested.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have added test instructions that prove my fix is effective or that my feature works.
